### PR TITLE
Add Firebase emulator local setup

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "sinyuubuturyuu-dev"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+firebase-emulators.err.log
+firebase-emulators.out.log
+firestore-debug.log
+http-server.err.log
+http-server.out.log
+launcher-server.err.log
+launcher-server.out.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,12 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Open Test Launcher",
+      "name": "Open Test Launcher without Firebase Emulator",
       "type": "pwa-chrome",
       "request": "launch",
-      "url": "http://127.0.0.1:8081",
+      "url": "http://127.0.0.1:8081/",
       "webRoot": "${workspaceFolder}",
-      "preLaunchTask": "Start Test Launcher"
+      "preLaunchTask": "Start Test Launcher without Firebase Emulator"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,8 +2,8 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Start Test Launcher",
-      "detail": "Start the local launcher without VS Code debugger hooks",
+      "label": "Start Test Launcher without Firebase Emulator",
+      "detail": "Start the local launcher without Firebase Emulator. This can connect to production Firebase.",
       "type": "shell",
       "command": "powershell",
       "args": [
@@ -36,5 +36,3 @@
     }
   ]
 }
-
-

--- a/docs/firebase-emulator-local-manual.md
+++ b/docs/firebase-emulator-local-manual.md
@@ -1,0 +1,240 @@
+# Firebase Emulator 起動・停止マニュアル
+
+対象リポジトリ:
+
+```powershell
+C:\GitHub\sinyuubuturyuu-apps3
+```
+
+## 1. エミュレーターを起動する
+
+PowerShell を開き、リポジトリ直下へ移動します。
+
+```powershell
+cd C:\GitHub\sinyuubuturyuu-apps3
+```
+
+Firebase Emulator と launcher をまとめて起動します。
+
+```powershell
+.\launcher\start-firebase-local-stack.ps1
+```
+
+実行すると、PowerShell ウィンドウが2つ開きます。
+
+```text
+1つ目: Firebase Emulator 用
+2つ目: launcher 用
+```
+
+## 2. 起動後に開く画面
+
+Firebase Emulator の管理画面:
+
+```text
+http://127.0.0.1:4000/
+```
+
+アプリをエミュレーター接続で開くURLは、launcher 用 PowerShell ウィンドウに表示されます。
+
+表示例:
+
+```text
+Launcher server running at http://127.0.0.1:8082
+Launcher mode: Firebase Emulator mode
+Open launcher: http://127.0.0.1:8082/
+Open mobile app: http://127.0.0.1:8082/sinyuubuturyuu/index.html
+Open PC app: http://127.0.0.1:8082/sinyuubuturyuu-pc/index.html
+Firebase emulator runtime injection enabled.
+Firebase Emulator target: http://127.0.0.1:8082/sinyuubuturyuu/index.html
+```
+
+この中で必ず確認する行:
+
+```text
+Firebase Emulator target:
+```
+
+この行に表示されたURLが、エミュレーター接続の対象アプリです。
+
+例:
+
+```text
+Firebase Emulator target: http://127.0.0.1:8082/sinyuubuturyuu/index.html
+```
+
+この場合、開くURLは以下です。
+
+```text
+http://127.0.0.1:8082/sinyuubuturyuu/index.html
+```
+
+## 3. なぜ 8081 ではなく 8082 になることがあるか
+
+通常 launcher がすでに `8081` を使っている場合、エミュレーター用 launcher は自動的に次のポートへ移動します。
+
+例:
+
+```text
+8081: 通常 launcher
+8082: エミュレーター用 launcher
+```
+
+そのため、エミュレーター接続で開くURLは固定ではありません。
+
+必ず launcher 用 PowerShell ウィンドウに表示される次の行を確認してください。
+
+```text
+Firebase Emulator target:
+```
+
+## 4. エミュレーターを停止する
+
+起動時に開いた2つの PowerShell ウィンドウで、それぞれ `Ctrl + C` を押します。
+
+```powershell
+Ctrl + C
+```
+
+停止する対象:
+
+```text
+1つ目: Firebase Emulator 用 PowerShell
+2つ目: launcher 用 PowerShell
+```
+
+Firebase Emulator 側では、次のような表示が出れば正常に停止中です。
+
+```text
+Received SIGINT (Ctrl-C)
+Starting a clean shutdown.
+Shutting down emulators.
+Stopping Emulator UI
+Stopping Firestore Emulator
+Stopping Authentication Emulator
+```
+
+PowerShell の入力待ちに戻れば停止完了です。
+
+```powershell
+PS C:\GitHub\sinyuubuturyuu-apps3>
+```
+
+## 5. 停止確認
+
+別の PowerShell で以下を実行します。
+
+```powershell
+netstat -ano | findstr ":4000 :4400 :8080 :8081 :8082 :9099 :9150"
+```
+
+`LISTENING` が出なければ停止済みです。
+
+停止済みでも、以下のような表示が一時的に残ることがあります。
+
+```text
+TIME_WAIT
+SYN_SENT
+```
+
+これは終了待ちの通信なので、基本的に問題ありません。
+
+## 6. 起動中の例
+
+エミュレーターが起動中の場合、以下のように `LISTENING` が表示されます。
+
+```text
+TCP 127.0.0.1:4000  0.0.0.0:0  LISTENING  <PID>
+TCP 127.0.0.1:4400  0.0.0.0:0  LISTENING  <PID>
+TCP 127.0.0.1:8080  0.0.0.0:0  LISTENING  <PID>
+TCP 0.0.0.0:8081    0.0.0.0:0  LISTENING  <PID>
+TCP 127.0.0.1:9099  0.0.0.0:0  LISTENING  <PID>
+TCP 127.0.0.1:9150  0.0.0.0:0  LISTENING  <PID>
+```
+
+`8082` で起動している場合もあります。
+
+```text
+TCP 0.0.0.0:8082    0.0.0.0:0  LISTENING  <PID>
+```
+
+## 7. 強制停止する場合
+
+`Ctrl + C` で止まらない場合は、`LISTENING` の右端に表示されている PID を指定して停止します。
+
+例:
+
+```text
+TCP 127.0.0.1:8080  0.0.0.0:0  LISTENING  10520
+```
+
+この場合:
+
+```powershell
+Stop-Process -Id 10520 -Force
+```
+
+複数まとめて止める場合:
+
+```powershell
+Stop-Process -Id <PID1>,<PID2>,<PID3> -Force
+```
+
+例:
+
+```powershell
+Stop-Process -Id 13208,10520,25808 -Force
+```
+
+## 8. 注意点
+
+`svchost.exe` は止めないでください。
+
+特に、以下のような `UDP 4500` が表示されることがあります。
+
+```text
+UDP 0.0.0.0:4500 *:* <PID>
+```
+
+この PID が `svchost.exe` の場合、それは Firebase Emulator ではありません。
+
+確認例:
+
+```powershell
+Get-Process -Id <PID>
+```
+
+`svchost.exe` の場合は停止しないでください。
+
+## 9. 通常ログインとの違い
+
+通常ログインで使う場合は、VSCode の Ctrl + F5 で launcher だけを起動します。
+
+通常起動では Firebase Emulator は使いません。
+
+```text
+通常起動:
+launcher のみ
+
+エミュレーター起動:
+Firebase Emulator + emulator 用 launcher
+```
+
+エミュレーターを使う場合だけ、以下を実行します。
+
+```powershell
+.\launcher\start-firebase-local-stack.ps1
+```
+
+## 10. 重要な確認ポイント
+
+エミュレーター接続でアプリを開くときは、必ず launcher 用 PowerShell ウィンドウの次の行を確認してください。
+
+```text
+Firebase Emulator target:
+```
+
+ここに表示されたURLを開いてください。
+
+`8081` とは限りません。  
+`8082` や別のポートになる場合があります。

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,26 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "auth": {
+      "host": "127.0.0.1",
+      "port": 9099
+    },
+    "firestore": {
+      "host": "127.0.0.1",
+      "port": 8080
+    },
+    "ui": {
+      "host": "127.0.0.1",
+      "port": 4000,
+      "enabled": true
+    },
+    "hub": {
+      "host": "127.0.0.1",
+      "port": 4400
+    },
+    "singleProjectMode": true
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // ローカルEmulator用: ローカル検証を優先するため全読み書きを許可します。
+    // 本番Firestoreルールとしては使用しないでください。
+    match /{document=**} {
+      allow read, write: if true;
+    }
+  }
+}

--- a/launcher/launcher-server.cjs
+++ b/launcher/launcher-server.cjs
@@ -7,6 +7,20 @@ const rootDir = path.resolve(__dirname, "..");
 const requestedPort = Number(process.argv[2] || process.env.PORT || 8080);
 const host = "0.0.0.0";
 const maxPortAttempts = 20;
+const firebaseEmulatorEnabled = String(process.env.APP_USE_FIREBASE_EMULATOR || "").toLowerCase() === "true";
+const firebaseEmulatorConfig = {
+  apiKey: "AIzaSyBBvJndQmecQfaetdjs9Pb6Z1TDmoQMOGc",
+  authDomain: "sinyuubuturyuu-dev.firebaseapp.com",
+  projectId: "sinyuubuturyuu-dev",
+  storageBucket: "sinyuubuturyuu-dev.firebasestorage.app",
+  messagingSenderId: "997788842966",
+  appId: "1:997788842966:web:e011e7340e2af863c40277"
+};
+const firebaseEmulatorRuntime = {
+  authUrl: "http://127.0.0.1:9099",
+  firestoreHost: "127.0.0.1",
+  firestorePort: 8080
+};
 
 const mimeTypes = new Map([
   [".html", "text/html; charset=utf-8"],
@@ -49,6 +63,28 @@ function serveJson(response, payload) {
     },
     JSON.stringify(payload, null, 2)
   );
+}
+
+function injectFirebaseEmulatorRuntime(filePath, data) {
+  if (!firebaseEmulatorEnabled || path.extname(filePath).toLowerCase() !== ".html") {
+    return data;
+  }
+
+  const html = data.toString("utf8");
+  const marker = "</head>";
+  if (!html.includes(marker)) {
+    return data;
+  }
+
+  const payload = [
+    "<script>",
+    "window.APP_USE_FIREBASE_EMULATOR = true;",
+    `window.APP_FIREBASE_EMULATOR_CONFIG = ${JSON.stringify(firebaseEmulatorConfig)};`,
+    `window.APP_FIREBASE_EMULATOR = ${JSON.stringify(firebaseEmulatorRuntime)};`,
+    "</script>"
+  ].join("");
+
+  return Buffer.from(html.replace(marker, `${payload}\n${marker}`), "utf8");
 }
 
 function pickLanAddress() {
@@ -112,7 +148,7 @@ const server = http.createServer((request, response) => {
 
       const extension = path.extname(filePath).toLowerCase();
       const contentType = mimeTypes.get(extension) || "application/octet-stream";
-      send(response, 200, { "Content-Type": contentType, "Cache-Control": "no-store" }, data);
+      send(response, 200, { "Content-Type": contentType, "Cache-Control": "no-store" }, injectFirebaseEmulatorRuntime(filePath, data));
     });
   });
 });
@@ -133,8 +169,20 @@ function startServer(port, attemptsRemaining) {
     const address = server.address();
     const activePort = address && typeof address === "object" ? address.port : port;
     const localhostUrl = `http://127.0.0.1:${activePort}`;
+    const mobileAppUrl = `${localhostUrl}/sinyuubuturyuu/index.html`;
+    const pcAppUrl = `${localhostUrl}/sinyuubuturyuu-pc/index.html`;
     const lanAddress = pickLanAddress();
+    const modeLabel = firebaseEmulatorEnabled ? "Firebase Emulator mode" : "Normal Firebase mode";
+
     console.log(`Launcher server running at ${localhostUrl}`);
+    console.log(`Launcher mode: ${modeLabel}`);
+    console.log(`Open launcher: ${localhostUrl}/`);
+    console.log(`Open mobile app: ${mobileAppUrl}`);
+    console.log(`Open PC app: ${pcAppUrl}`);
+    if (firebaseEmulatorEnabled) {
+      console.log("Firebase emulator runtime injection enabled.");
+      console.log(`Firebase Emulator target: ${mobileAppUrl}`);
+    }
     if (lanAddress) {
       console.log(`LAN access URL: http://${lanAddress}:${activePort}`);
     }

--- a/launcher/start-firebase-local-stack.ps1
+++ b/launcher/start-firebase-local-stack.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = "Stop"
+
+$rootDir = Resolve-Path (Join-Path $PSScriptRoot "..")
+$rootLiteral = $rootDir.Path.Replace("'", "''")
+
+function New-TaskPowerShellArgs {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Command
+  )
+
+  return @(
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-NoExit",
+    "-Command",
+    $Command
+  )
+}
+
+$firebaseCommand = "Set-Location -LiteralPath '$rootLiteral'; `$env:FIREBASE_CLI_DISABLE_UPDATE_CHECK='true'; firebase.cmd emulators:start --only auth,firestore"
+$launcherCommand = "Set-Location -LiteralPath '$rootLiteral'; Remove-Item Env:NODE_OPTIONS -ErrorAction SilentlyContinue; Remove-Item Env:VSCODE_INSPECTOR_OPTIONS -ErrorAction SilentlyContinue; `$env:APP_USE_FIREBASE_EMULATOR='true'; node .\launcher\launcher-server.cjs 8081"
+
+Start-Process -FilePath "powershell.exe" -ArgumentList (New-TaskPowerShellArgs -Command $firebaseCommand) -WorkingDirectory $rootDir.Path
+Start-Sleep -Seconds 2
+Start-Process -FilePath "powershell.exe" -ArgumentList (New-TaskPowerShellArgs -Command $launcherCommand) -WorkingDirectory $rootDir.Path
+
+Write-Host "Firebase Emulator and launcher startup commands were opened."
+Write-Host "Emulator UI: http://127.0.0.1:4000"
+Write-Host "Launcher window shows the exact app URL."
+Write-Host "If port 8081 is busy, the emulator launcher may use 8082 or another port."

--- a/sinyuubuturyuu-pc/auth/firebase-auth.js
+++ b/sinyuubuturyuu-pc/auth/firebase-auth.js
@@ -6,7 +6,8 @@
   let runtimePromise = null;
 
   function getFirebaseConfig() {
-    return window.APP_FIREBASE_CONFIG || window.APP_FIREBASE_DIRECTORY_CONFIG || {};
+    const config = window.APP_FIREBASE_CONFIG || window.APP_FIREBASE_DIRECTORY_CONFIG || {};
+    return shouldUseFirebaseEmulator() ? { ...config, ...getFirebaseEmulatorConfig() } : config;
   }
 
   function hasFirebaseConfig(config) {
@@ -14,6 +15,39 @@
       const value = config && config[key];
       return typeof value === "string" && value.trim();
     });
+  }
+
+  function isLocalDevelopmentHost() {
+    const host = window.location.hostname;
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+  }
+
+  function shouldUseFirebaseEmulator() {
+    return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+  }
+
+  function getFirebaseEmulatorConfig() {
+    return window.APP_FIREBASE_EMULATOR_CONFIG || {};
+  }
+
+  function getFirebaseEmulatorRuntime() {
+    return {
+      authUrl: "http://127.0.0.1:9099",
+      ...(window.APP_FIREBASE_EMULATOR || {})
+    };
+  }
+
+  function connectAuthEmulatorIfNeeded(authModule, auth) {
+    if (!shouldUseFirebaseEmulator() || !authModule || typeof authModule.connectAuthEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    authModule.connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+    auth.__sinyuubuturyuuEmulatorConnected = true;
   }
 
   async function ensureRuntime() {
@@ -36,9 +70,12 @@
         ? getApp()
         : initializeApp(config);
 
+      const auth = authModule.getAuth(app);
+      connectAuthEmulatorIfNeeded(authModule, auth);
+
       return {
         app,
-        auth: authModule.getAuth(app),
+        auth,
         authModule
       };
     })().catch((error) => {

--- a/sinyuubuturyuu-pc/getujinitijyoutenkenhyou-pc/src/main.js
+++ b/sinyuubuturyuu-pc/getujinitijyoutenkenhyou-pc/src/main.js
@@ -1,9 +1,10 @@
 ﻿import { getApp, getApps, initializeApp } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js";
-import { getAuth, updateCurrentUser } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js";
+import { connectAuthEmulator, getAuth, updateCurrentUser } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js";
 import {
   collection,
   deleteDoc,
   doc,
+  connectFirestoreEmulator,
   getDoc,
   getDocs,
   getFirestore,
@@ -53,7 +54,7 @@ const EXCEL_CUSTOM_STAMP_ASSETS = {
 let jsZipModulePromise = null;
 const stampSvgMarkupPromiseCache = new Map();
 
-const firebaseConfig = window.APP_FIREBASE_CONFIG || {
+const firebaseConfig = getRuntimeFirebaseConfig(window.APP_FIREBASE_CONFIG || {
   apiKey: "AIzaSyCUhbTrb3c5wN3zeJkFHzYvdWtN777hpNk",
   authDomain: "sinyuubuturyuu-86aeb.firebaseapp.com",
   projectId: "sinyuubuturyuu-86aeb",
@@ -61,9 +62,9 @@ const firebaseConfig = window.APP_FIREBASE_CONFIG || {
   messagingSenderId: "213947378677",
   appId: "1:213947378677:web:03b73a0dc7d710a9900ebc",
   measurementId: "G-F9VYGCTHEV"
-};
+});
 
-const referenceFirebaseConfig = {
+const referenceFirebaseConfig = getRuntimeFirebaseConfig({
   apiKey: "AIzaSyCUhbTrb3c5wN3zeJkFHzYvdWtN777hpNk",
   authDomain: "sinyuubuturyuu-86aeb.firebaseapp.com",
   projectId: "sinyuubuturyuu-86aeb",
@@ -71,7 +72,7 @@ const referenceFirebaseConfig = {
   messagingSenderId: "213947378677",
   appId: "1:213947378677:web:03b73a0dc7d710a9900ebc",
   measurementId: "G-F9VYGCTHEV"
-};
+});
 
 const FIRESTORE_COLLECTION = "getujinitijyoutenkenhyou";
 const VEHICLE_SETTINGS_DOC = {
@@ -83,6 +84,53 @@ const DRIVER_SETTINGS_DOC = {
   id: "monthly_tire_company_settings_backup_drivers_slot1"
 };
 const sharedSettings = window.SharedAppSettings || null;
+
+function isLocalDevelopmentHost() {
+  const host = window.location.hostname;
+  return host === "localhost"
+    || host === "127.0.0.1"
+    || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+    || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+    || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+function shouldUseFirebaseEmulator() {
+  return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+}
+
+function getRuntimeFirebaseConfig(config) {
+  return shouldUseFirebaseEmulator()
+    ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+    : (config || {});
+}
+
+function getFirebaseEmulatorRuntime() {
+  return {
+    authUrl: "http://127.0.0.1:9099",
+    firestoreHost: "127.0.0.1",
+    firestorePort: 8080,
+    ...(window.APP_FIREBASE_EMULATOR || {})
+  };
+}
+
+function connectAuthEmulatorIfNeeded(auth) {
+  if (!shouldUseFirebaseEmulator() || !auth || auth.__sinyuubuturyuuEmulatorConnected) {
+    return;
+  }
+
+  connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+  auth.__sinyuubuturyuuEmulatorConnected = true;
+}
+
+function connectFirestoreEmulatorIfNeeded(database) {
+  if (!shouldUseFirebaseEmulator() || !database || database.__sinyuubuturyuuEmulatorConnected) {
+    return;
+  }
+
+  const runtime = getFirebaseEmulatorRuntime();
+  connectFirestoreEmulator(database, runtime.firestoreHost, runtime.firestorePort);
+  database.__sinyuubuturyuuEmulatorConnected = true;
+}
 const CHECK_FIELD_ORDER = [
   "brake_pedal",
   "brake_fluid",
@@ -210,6 +258,10 @@ const auth = getAuth(app);
 const referenceApp = firebaseConfig.projectId === referenceFirebaseConfig.projectId ? app : initializeApp(referenceFirebaseConfig, "reference-app");
 const referenceDb = getFirestore(referenceApp);
 const referenceAuth = getAuth(referenceApp);
+connectFirestoreEmulatorIfNeeded(db);
+connectAuthEmulatorIfNeeded(auth);
+connectFirestoreEmulatorIfNeeded(referenceDb);
+connectAuthEmulatorIfNeeded(referenceAuth);
 
 function normalizeOptionValue(value) {
   return typeof value === "string" ? value.trim() : "";

--- a/sinyuubuturyuu-pc/settings.js
+++ b/sinyuubuturyuu-pc/settings.js
@@ -61,6 +61,52 @@
     }
   };
 
+  function isLocalDevelopmentHost() {
+    const host = window.location.hostname;
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+  }
+
+  function shouldUseFirebaseEmulator() {
+    return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+  }
+
+  function getRuntimeFirebaseConfig(config) {
+    return shouldUseFirebaseEmulator()
+      ? Object.assign({}, config || {}, window.APP_FIREBASE_EMULATOR_CONFIG || {})
+      : (config || {});
+  }
+
+  function getFirebaseEmulatorRuntime() {
+    return Object.assign({
+      authUrl: "http://127.0.0.1:9099",
+      firestoreHost: "127.0.0.1",
+      firestorePort: 8080
+    }, window.APP_FIREBASE_EMULATOR || {});
+  }
+
+  function connectCompatAuthEmulatorIfNeeded(auth) {
+    if (!shouldUseFirebaseEmulator() || !auth || typeof auth.useEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    auth.useEmulator(getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+    auth.__sinyuubuturyuuEmulatorConnected = true;
+  }
+
+  function connectCompatFirestoreEmulatorIfNeeded(db) {
+    if (!shouldUseFirebaseEmulator() || !db || typeof db.useEmulator !== "function" || db.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    const runtime = getFirebaseEmulatorRuntime();
+    db.useEmulator(runtime.firestoreHost, runtime.firestorePort);
+    db.__sinyuubuturyuuEmulatorConnected = true;
+  }
+
   bindEvents();
   render();
   void initializeCloud();
@@ -536,7 +582,7 @@
       throw new Error("firebase_config_missing");
     }
 
-    return ensureDb(window.APP_FIREBASE_CONFIG, window.APP_FIREBASE_SYNC_OPTIONS || {}, null);
+    return ensureDb(getRuntimeFirebaseConfig(window.APP_FIREBASE_CONFIG), window.APP_FIREBASE_SYNC_OPTIONS || {}, null);
   }
 
   async function ensureDirectoryDb() {
@@ -546,7 +592,7 @@
 
     const syncOptions = window.APP_FIREBASE_DIRECTORY_SYNC_OPTIONS || {};
     return ensureDb(
-      window.APP_FIREBASE_DIRECTORY_CONFIG,
+      getRuntimeFirebaseConfig(window.APP_FIREBASE_DIRECTORY_CONFIG),
       syncOptions,
       syncOptions.appName || "sinyuubuturyuu-directory"
     );
@@ -555,6 +601,7 @@
   async function ensureDb(config, syncOptions, appName) {
     const app = getOrCreateFirebaseApp(config, appName);
     const auth = app.auth();
+    connectCompatAuthEmulatorIfNeeded(auth);
     const authApi = window.DevFirebaseAuth;
 
     if (authApi && typeof authApi.ensureCompatUser === "function") {
@@ -563,7 +610,9 @@
       throw new Error("ログインしてください。");
     }
 
-    return app.firestore();
+    const db = app.firestore();
+    connectCompatFirestoreEmulatorIfNeeded(db);
+    return db;
   }
 
   function getCollectionName() {

--- a/sinyuubuturyuu/auth/firebase-auth.js
+++ b/sinyuubuturyuu/auth/firebase-auth.js
@@ -6,7 +6,8 @@
   let runtimePromise = null;
 
   function getFirebaseConfig() {
-    return window.APP_FIREBASE_CONFIG || window.APP_FIREBASE_DIRECTORY_CONFIG || {};
+    const config = window.APP_FIREBASE_CONFIG || window.APP_FIREBASE_DIRECTORY_CONFIG || {};
+    return shouldUseFirebaseEmulator() ? { ...config, ...getFirebaseEmulatorConfig() } : config;
   }
 
   function hasFirebaseConfig(config) {
@@ -14,6 +15,39 @@
       const value = config && config[key];
       return typeof value === "string" && value.trim();
     });
+  }
+
+  function isLocalDevelopmentHost() {
+    const host = window.location.hostname;
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+  }
+
+  function shouldUseFirebaseEmulator() {
+    return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+  }
+
+  function getFirebaseEmulatorConfig() {
+    return window.APP_FIREBASE_EMULATOR_CONFIG || {};
+  }
+
+  function getFirebaseEmulatorRuntime() {
+    return {
+      authUrl: "http://127.0.0.1:9099",
+      ...(window.APP_FIREBASE_EMULATOR || {})
+    };
+  }
+
+  function connectAuthEmulatorIfNeeded(authModule, auth) {
+    if (!shouldUseFirebaseEmulator() || !authModule || typeof authModule.connectAuthEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    authModule.connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+    auth.__sinyuubuturyuuEmulatorConnected = true;
   }
 
   async function ensureRuntime() {
@@ -36,9 +70,12 @@
         ? getApp()
         : initializeApp(config);
 
+      const auth = authModule.getAuth(app);
+      connectAuthEmulatorIfNeeded(authModule, auth);
+
       return {
         app,
-        auth: authModule.getAuth(app),
+        auth,
         authModule
       };
     })().catch((error) => {

--- a/sinyuubuturyuu/driver-points/driver-points.js
+++ b/sinyuubuturyuu/driver-points/driver-points.js
@@ -20,7 +20,7 @@
     summaryPrefix: "driver_points_summary",
     eventPrefix: "driver_points_event"
   });
-  const FIREBASE_CONFIG = Object.freeze({
+  const FIREBASE_CONFIG = Object.freeze(getRuntimeFirebaseConfig({
     apiKey: "AIzaSyCUhbTrb3c5wN3zeJkFHzYvdWtN777hpNk",
     authDomain: "sinyuubuturyuu-86aeb.firebaseapp.com",
     projectId: "sinyuubuturyuu-86aeb",
@@ -28,7 +28,7 @@
     messagingSenderId: "213947378677",
     appId: "1:213947378677:web:03b73a0dc7d710a9900ebc",
     measurementId: "G-F9VYGCTHEV"
-  });
+  }));
 
   const uiState = {
     mounted: false,
@@ -46,6 +46,43 @@
 
   function normalizeText(value) {
     return String(value ?? "").trim();
+  }
+
+  function isLocalDevelopmentHost() {
+    const host = window.location.hostname;
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+  }
+
+  function shouldUseFirebaseEmulator() {
+    return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+  }
+
+  function getRuntimeFirebaseConfig(config) {
+    return shouldUseFirebaseEmulator()
+      ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+      : (config || {});
+  }
+
+  function getFirebaseEmulatorRuntime() {
+    return {
+      firestoreHost: "127.0.0.1",
+      firestorePort: 8080,
+      ...(window.APP_FIREBASE_EMULATOR || {})
+    };
+  }
+
+  function connectFirestoreEmulatorIfNeeded(firestoreModule, db) {
+    if (!shouldUseFirebaseEmulator() || !firestoreModule || typeof firestoreModule.connectFirestoreEmulator !== "function" || db.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    const runtime = getFirebaseEmulatorRuntime();
+    firestoreModule.connectFirestoreEmulator(db, runtime.firestoreHost, runtime.firestorePort);
+    db.__sinyuubuturyuuEmulatorConnected = true;
   }
 
   function normalizeDriverName(value) {
@@ -266,8 +303,11 @@
         throw new Error("ログインしてください。");
       }
 
+      const db = firestoreModule.getFirestore(app);
+      connectFirestoreEmulatorIfNeeded(firestoreModule, db);
+
       return {
-        db: firestoreModule.getFirestore(app),
+        db,
         firestoreModule
       };
     })().catch((error) => {

--- a/sinyuubuturyuu/getujinitijyoutenkenhyou/app.js
+++ b/sinyuubuturyuu/getujinitijyoutenkenhyou/app.js
@@ -24,6 +24,53 @@ const MONTHLY_COMPLETE_IMAGE_SRC = "./icons/monthly-complete.png";
 const MONTHLY_COMPLETE_IMAGE_ALT = "今月分はすべて完了しました。明日もよろしくお願いします。";
 const sharedSettings = window.SharedLauncherSettings || null;
 
+function isLocalDevelopmentHost() {
+  const host = window.location.hostname;
+  return host === "localhost"
+    || host === "127.0.0.1"
+    || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+    || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+    || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+function shouldUseFirebaseEmulator() {
+  return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+}
+
+function getRuntimeFirebaseConfig(config) {
+  return shouldUseFirebaseEmulator()
+    ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+    : (config || {});
+}
+
+function getFirebaseEmulatorRuntime() {
+  return {
+    authUrl: "http://127.0.0.1:9099",
+    firestoreHost: "127.0.0.1",
+    firestorePort: 8080,
+    ...(window.APP_FIREBASE_EMULATOR || {})
+  };
+}
+
+function connectAuthEmulatorIfNeeded(authModule, auth) {
+  if (!shouldUseFirebaseEmulator() || !authModule || typeof authModule.connectAuthEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+    return;
+  }
+
+  authModule.connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+  auth.__sinyuubuturyuuEmulatorConnected = true;
+}
+
+function connectFirestoreEmulatorIfNeeded(firestoreModule, db) {
+  if (!shouldUseFirebaseEmulator() || !firestoreModule || typeof firestoreModule.connectFirestoreEmulator !== "function" || db.__sinyuubuturyuuEmulatorConnected) {
+    return;
+  }
+
+  const runtime = getFirebaseEmulatorRuntime();
+  firestoreModule.connectFirestoreEmulator(db, runtime.firestoreHost, runtime.firestorePort);
+  db.__sinyuubuturyuuEmulatorConnected = true;
+}
+
 const INSPECTION_GROUPS = [
   {
     id: "brake",
@@ -576,8 +623,9 @@ async function createStore() {
 
     const app = typeof getApps === "function" && getApps().length
       ? getApp()
-      : initializeApp(firebaseConfig);
+      : initializeApp(getRuntimeFirebaseConfig(firebaseConfig));
     const auth = authModule.getAuth(app);
+    connectAuthEmulatorIfNeeded(authModule, auth);
     if (!auth.currentUser && typeof auth.authStateReady === "function") {
       await auth.authStateReady();
     }
@@ -585,6 +633,7 @@ async function createStore() {
       throw new Error("ログインしてください。");
     }
     const db = firestoreModule.getFirestore(app);
+    connectFirestoreEmulatorIfNeeded(firestoreModule, db);
     return createFirestoreStore(db, firestoreModule);
   } catch (error) {
     console.error(error);

--- a/sinyuubuturyuu/getujitiretenkenhyou/app.js
+++ b/sinyuubuturyuu/getujitiretenkenhyou/app.js
@@ -37,7 +37,7 @@
         SETTINGS: "settings"
       };
       const sharedSettings = window.SharedLauncherSettings || null;
-      const REFERENCE_FIREBASE_CONFIG = window.APP_FIREBASE_DIRECTORY_CONFIG || window.APP_FIREBASE_CONFIG || {};
+      const REFERENCE_FIREBASE_CONFIG = getRuntimeFirebaseConfig(window.APP_FIREBASE_DIRECTORY_CONFIG || window.APP_FIREBASE_CONFIG || {});
       const REFERENCE_SOURCE_KIND = Object.freeze({
         VEHICLES: "vehicles",
         DRIVERS: "drivers"
@@ -52,6 +52,53 @@
           docId: String((((window.APP_FIREBASE_DIRECTORY_SYNC_OPTIONS || {}).docIds || {}).drivers) || "monthly_tire_company_settings_backup_drivers_slot1").trim() || "monthly_tire_company_settings_backup_drivers_slot1"
         })
       });
+
+      function isLocalDevelopmentHost() {
+        const host = window.location.hostname;
+        return host === "localhost"
+          || host === "127.0.0.1"
+          || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+          || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+          || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+      }
+
+      function shouldUseFirebaseEmulator() {
+        return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+      }
+
+      function getRuntimeFirebaseConfig(config) {
+        return shouldUseFirebaseEmulator()
+          ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+          : (config || {});
+      }
+
+      function getFirebaseEmulatorRuntime() {
+        return {
+          authUrl: "http://127.0.0.1:9099",
+          firestoreHost: "127.0.0.1",
+          firestorePort: 8080,
+          ...(window.APP_FIREBASE_EMULATOR || {})
+        };
+      }
+
+      function connectAuthEmulatorIfNeeded(authModule, auth) {
+        if (!shouldUseFirebaseEmulator() || !authModule || typeof authModule.connectAuthEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+          return;
+        }
+
+        authModule.connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+        auth.__sinyuubuturyuuEmulatorConnected = true;
+      }
+
+      function connectFirestoreEmulatorIfNeeded(firestoreModule, db) {
+        if (!shouldUseFirebaseEmulator() || !firestoreModule || typeof firestoreModule.connectFirestoreEmulator !== "function" || db.__sinyuubuturyuuEmulatorConnected) {
+          return;
+        }
+
+        const runtime = getFirebaseEmulatorRuntime();
+        firestoreModule.connectFirestoreEmulator(db, runtime.firestoreHost, runtime.firestorePort);
+        db.__sinyuubuturyuuEmulatorConnected = true;
+      }
 
       const DISPLAY_MAP_12 = ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩", "⑪", "⑫"];
       const DISPLAY_MAP_10 = ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩"];
@@ -761,9 +808,14 @@
             ? appModule.getApp()
             : appModule.initializeApp(REFERENCE_FIREBASE_CONFIG);
 
+          const auth = authModule.getAuth(app);
+          const db = firestoreModule.getFirestore(app);
+          connectAuthEmulatorIfNeeded(authModule, auth);
+          connectFirestoreEmulatorIfNeeded(firestoreModule, db);
+
           return {
-            auth: authModule.getAuth(app),
-            db: firestoreModule.getFirestore(app),
+            auth,
+            db,
             firestoreModule
           };
         })().catch((error) => {

--- a/sinyuubuturyuu/getujitiretenkenhyou/firebase/firebase-cloud-sync.js
+++ b/sinyuubuturyuu/getujitiretenkenhyou/firebase/firebase-cloud-sync.js
@@ -41,6 +41,53 @@
     flushing: false
   };
 
+  function isLocalDevelopmentHost() {
+    const host = window.location.hostname;
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+  }
+
+  function shouldUseFirebaseEmulator() {
+    return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+  }
+
+  function getRuntimeFirebaseConfig(config) {
+    return shouldUseFirebaseEmulator()
+      ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+      : (config || {});
+  }
+
+  function getFirebaseEmulatorRuntime() {
+    return {
+      authUrl: "http://127.0.0.1:9099",
+      firestoreHost: "127.0.0.1",
+      firestorePort: 8080,
+      ...(window.APP_FIREBASE_EMULATOR || {})
+    };
+  }
+
+  function connectCompatAuthEmulatorIfNeeded(auth) {
+    if (!shouldUseFirebaseEmulator() || !auth || typeof auth.useEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    auth.useEmulator(getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+    auth.__sinyuubuturyuuEmulatorConnected = true;
+  }
+
+  function connectCompatFirestoreEmulatorIfNeeded(db) {
+    if (!shouldUseFirebaseEmulator() || !db || typeof db.useEmulator !== "function" || db.__sinyuubuturyuuEmulatorConnected) {
+      return;
+    }
+
+    const runtime = getFirebaseEmulatorRuntime();
+    db.useEmulator(runtime.firestoreHost, runtime.firestorePort);
+    db.__sinyuubuturyuuEmulatorConnected = true;
+  }
+
   function log(message, extra) {
     if (extra === undefined) {
       console.info("[FirebaseCloudSync]", message);
@@ -382,7 +429,7 @@
     if (state.readyPromise) return state.readyPromise;
 
     state.readyPromise = (async () => {
-      const config = window.APP_FIREBASE_CONFIG || {};
+      const config = getRuntimeFirebaseConfig(window.APP_FIREBASE_CONFIG || {});
       const required = ["apiKey", "authDomain", "projectId", "appId"];
       const missing = required.filter((key) => !String(config[key] || "").trim());
       if (missing.length > 0) {
@@ -397,6 +444,8 @@
 
       state.auth = state.firebase.auth();
       state.db = state.firebase.firestore();
+      connectCompatAuthEmulatorIfNeeded(state.auth);
+      connectCompatFirestoreEmulatorIfNeeded(state.db);
       state.deviceId = getOrCreateDeviceId();
 
       if (!state.auth.currentUser && typeof state.auth.authStateReady === "function") {
@@ -423,7 +472,7 @@
     if (state.directoryReadyPromise) return state.directoryReadyPromise;
 
     state.directoryReadyPromise = (async () => {
-      const config = window.APP_FIREBASE_DIRECTORY_CONFIG || {};
+      const config = getRuntimeFirebaseConfig(window.APP_FIREBASE_DIRECTORY_CONFIG || {});
       const syncOptions = window.APP_FIREBASE_DIRECTORY_SYNC_OPTIONS || {};
       const required = ["apiKey", "authDomain", "projectId", "appId"];
       const missing = required.filter((key) => !String(config[key] || "").trim());
@@ -434,6 +483,7 @@
       state.firebase = state.firebase || await ensureFirebaseSdk();
       const app = getOrCreateFirebaseApp(config, syncOptions.appName || "sinyuubuturyuu-directory");
       const auth = app.auth();
+      connectCompatAuthEmulatorIfNeeded(auth);
       if (!auth.currentUser && typeof auth.authStateReady === "function") {
         await auth.authStateReady();
       }
@@ -445,6 +495,7 @@
       state.directoryApp = app;
       state.directoryAuth = auth;
       state.directoryDb = app.firestore();
+      connectCompatFirestoreEmulatorIfNeeded(state.directoryDb);
       state.uid = auth.currentUser.uid || state.uid || "";
       state.deviceId = state.deviceId || getOrCreateDeviceId();
       return true;

--- a/sinyuubuturyuu/launcher.js
+++ b/sinyuubuturyuu/launcher.js
@@ -6,7 +6,7 @@
 };
 
 const MONTHLY_COMPLETE_IMAGE_SRC = "./getujitiretenkenhyou/icons/monthly-complete.png";
-const REFERENCE_FIREBASE_CONFIG = Object.freeze(window.APP_FIREBASE_DIRECTORY_CONFIG || {
+const REFERENCE_FIREBASE_CONFIG = Object.freeze(getRuntimeFirebaseConfig(window.APP_FIREBASE_DIRECTORY_CONFIG || {
   apiKey: "AIzaSyCUhbTrb3c5wN3zeJkFHzYvdWtN777hpNk",
   authDomain: "sinyuubuturyuu-86aeb.firebaseapp.com",
   projectId: "sinyuubuturyuu-86aeb",
@@ -14,7 +14,7 @@ const REFERENCE_FIREBASE_CONFIG = Object.freeze(window.APP_FIREBASE_DIRECTORY_CO
   messagingSenderId: "213947378677",
   appId: "1:213947378677:web:03b73a0dc7d710a9900ebc",
   measurementId: "G-F9VYGCTHEV",
-});
+}));
 const REFERENCE_SOURCE_KIND = Object.freeze({
   VEHICLES: "vehicles",
   DRIVERS: "drivers",
@@ -39,7 +39,7 @@ const MONTHLY_COMPLETE_IMAGE_ALT = "Monthly inspection complete.";
 const DAILY_INSPECTION_COMPLETE_IMAGE_SRC = "./getujinitijyoutenkenhyou/icons/monthly-complete.png";
 const DAILY_INSPECTION_COMPLETE_IMAGE_ALT = "Daily inspection complete for this month.";
 const LAUNCH_RETRY_MESSAGE = "通信状態を確認して、もう一度タップしてください。";
-const DAILY_INSPECTION_FIREBASE_CONFIG = Object.freeze({
+const DAILY_INSPECTION_FIREBASE_CONFIG = Object.freeze(getRuntimeFirebaseConfig({
   apiKey: "AIzaSyCUhbTrb3c5wN3zeJkFHzYvdWtN777hpNk",
   authDomain: "sinyuubuturyuu-86aeb.firebaseapp.com",
   projectId: "sinyuubuturyuu-86aeb",
@@ -47,7 +47,7 @@ const DAILY_INSPECTION_FIREBASE_CONFIG = Object.freeze({
   messagingSenderId: "213947378677",
   appId: "1:213947378677:web:03b73a0dc7d710a9900ebc",
   measurementId: "G-F9VYGCTHEV",
-});
+}));
 const DAILY_INSPECTION_APP_SETTINGS = Object.freeze({
   collectionName: "getujinitijyoutenkenhyou",
   useLocalFallbackWhenFirebaseIsMissing: true,
@@ -83,6 +83,53 @@ const DAILY_INSPECTION_ITEM_IDS = Object.freeze([
   "report_changes",
 ]);
 const sharedSettings = window.SharedLauncherSettings;
+
+function isLocalDevelopmentHost() {
+  const host = window.location.hostname;
+  return host === "localhost"
+    || host === "127.0.0.1"
+    || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+    || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+    || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+function shouldUseFirebaseEmulator() {
+  return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+}
+
+function getRuntimeFirebaseConfig(config) {
+  return shouldUseFirebaseEmulator()
+    ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+    : (config || {});
+}
+
+function getFirebaseEmulatorRuntime() {
+  return {
+    authUrl: "http://127.0.0.1:9099",
+    firestoreHost: "127.0.0.1",
+    firestorePort: 8080,
+    ...(window.APP_FIREBASE_EMULATOR || {}),
+  };
+}
+
+function connectAuthEmulatorIfNeeded(authModule, auth) {
+  if (!shouldUseFirebaseEmulator() || !authModule || typeof authModule.connectAuthEmulator !== "function" || auth.__sinyuubuturyuuEmulatorConnected) {
+    return;
+  }
+
+  authModule.connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+  auth.__sinyuubuturyuuEmulatorConnected = true;
+}
+
+function connectFirestoreEmulatorIfNeeded(firestoreModule, db) {
+  if (!shouldUseFirebaseEmulator() || !firestoreModule || typeof firestoreModule.connectFirestoreEmulator !== "function" || db.__sinyuubuturyuuEmulatorConnected) {
+    return;
+  }
+
+  const runtime = getFirebaseEmulatorRuntime();
+  firestoreModule.connectFirestoreEmulator(db, runtime.firestoreHost, runtime.firestorePort);
+  db.__sinyuubuturyuuEmulatorConnected = true;
+}
 
 const elements = {
   app1Button: document.getElementById("app1Button"),
@@ -602,10 +649,15 @@ async function getReferenceSettingsRuntime() {
       ? appModule.getApp()
       : appModule.initializeApp(REFERENCE_FIREBASE_CONFIG);
 
+    const auth = authModule.getAuth(app);
+    const db = firestoreModule.getFirestore(app);
+    connectAuthEmulatorIfNeeded(authModule, auth);
+    connectFirestoreEmulatorIfNeeded(firestoreModule, db);
+
     return {
-      auth: authModule.getAuth(app),
+      auth,
       authModule,
-      db: firestoreModule.getFirestore(app),
+      db,
       firestoreModule,
     };
   })().catch((error) => {
@@ -1324,6 +1376,7 @@ async function listDailyInspectionRecords(vehicle, driver) {
     ? getApp()
     : initializeApp(runtime.firebaseConfig);
   const auth = authModule.getAuth(app);
+  connectAuthEmulatorIfNeeded(authModule, auth);
   if (!auth.currentUser && typeof auth.authStateReady === "function") {
     await auth.authStateReady();
   }
@@ -1331,6 +1384,7 @@ async function listDailyInspectionRecords(vehicle, driver) {
     throw new Error("ログインしてください。");
   }
   const db = firestoreModule.getFirestore(app);
+  connectFirestoreEmulatorIfNeeded(firestoreModule, db);
   const collectionName = String(runtime.appSettings.collectionName || "getujinitijyoutenkenhyou");
   const ref = firestoreModule.collection(db, collectionName);
   const queries = [


### PR DESCRIPTION
## 内容
- Firebase Emulator のローカル設定を追加
- Emulator 起動用スクリプトを追加
- launcher で Emulator 対象URLを表示
- 通常起動では Emulator を使わない VSCode 設定に整理
- アプリ側で Emulator 接続時のみ Auth / Firestore Emulator を使うよう対応

## 確認
- launcher-server.cjs の構文チェック済み
- 通常起動では Emulator 注入なし
- Emulator 起動時は Firebase Emulator target が表示される
