### PR TITLE
管理者用データ調整ページ追加と社員ポイント一覧の整理 

### DIFF
--- a/sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.css
+++ b/sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.css
@@ -1,0 +1,253 @@
+.adjustment-page {
+  place-items: start center;
+}
+
+.adjustment-card {
+  width: min(100%, 1120px);
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+}
+
+.adjustment-section {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.adjustment-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.adjustment-summary {
+  grid-template-columns: minmax(240px, 0.72fr) minmax(420px, 1.28fr);
+}
+
+.month-overview {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.overview-item {
+  min-height: 96px;
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.overview-item span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.overview-item strong {
+  color: var(--primary);
+  font-size: 1.35rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.table-wrap {
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.event-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.event-table th,
+.event-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.event-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #eef4f9;
+}
+
+.event-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.event-table input[type="radio"] {
+  width: 18px;
+  height: 18px;
+}
+
+.event-source {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(12, 93, 125, 0.1);
+  color: var(--primary);
+  font-size: 0.86rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.event-meta {
+  display: grid;
+  gap: 3px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.review-section[hidden] {
+  display: none;
+}
+
+.review-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.review-panel {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.review-panel h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.review-list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  list-style: none;
+}
+
+.review-list li {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: #f4f7fa;
+  line-height: 1.55;
+}
+
+.review-list li.ok {
+  background: rgba(35, 133, 79, 0.12);
+  color: #1d6f43;
+  font-weight: 700;
+}
+
+.review-list li.warning {
+  background: rgba(189, 127, 28, 0.16);
+  color: #875a13;
+  font-weight: 700;
+}
+
+.review-list li.error {
+  background: rgba(176, 0, 32, 0.12);
+  color: #b00020;
+  font-weight: 700;
+}
+
+.summary-change {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(12, 93, 125, 0.1);
+  color: var(--primary);
+  font-weight: 800;
+}
+
+.danger-zone {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid rgba(199, 61, 61, 0.3);
+  border-radius: 18px;
+  background: rgba(199, 61, 61, 0.08);
+}
+
+.danger-zone p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.danger-zone .mini-button {
+  min-width: 150px;
+}
+
+.mini-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}
+
+a.mini-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+@media (max-width: 980px) {
+  .adjustment-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .adjustment-summary,
+  .review-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .month-overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .adjustment-card {
+    padding: 20px;
+  }
+
+  .adjustment-grid,
+  .month-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .danger-zone {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .danger-zone .mini-button {
+    width: 100%;
+  }
+}

--- a/sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.html
+++ b/sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="../version-sync.js"></script>
+  <script>
+    (function () {
+      const versionSync = window.SinyuubuturyuuPcVersion || null;
+      const version = versionSync ? versionSync.ensureLatestVersion("20260404a") : "20260404a";
+      if (!version) return;
+      window.__SINYUUBUTURYUU_PC_VERSION__ = version;
+    })();
+  </script>
+  <title>管理者用データ調整 | シンユウ物流パソコン用</title>
+  <meta name="description" content="点検データとポイント履歴を確認し、整合性を保って削除する管理者用ページ">
+  <link rel="icon" href="../icons/icon-sinyuubuturyuu-pc.png" type="image/png">
+  <link rel="apple-touch-icon" href="../icons/icon-sinyuubuturyuu-pc.png">
+  <link rel="manifest" href="../manifest.webmanifest?v=20260404b">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="../shell.css?v=20260404b">
+  <link rel="stylesheet" href="./driver-points-kanri.css?v=20260404a">
+  <link rel="stylesheet" href="./data-adjustment.css?v=20260404a">
+</head>
+<body class="shell-body">
+  <main class="shell-page adjustment-page">
+    <section class="shell-card adjustment-card">
+      <div class="settings-topbar">
+        <a class="back-link" href="../index.html">トップへ戻る</a>
+        <h1>管理者用データ調整</h1>
+      </div>
+
+      <section class="adjustment-section" aria-labelledby="selectionHeading">
+        <div class="section-head">
+          <h2 id="selectionHeading">対象の選択</h2>
+        </div>
+
+        <div class="adjustment-grid">
+          <label class="field">
+            <span>乗務員</span>
+            <select id="driverSelect">
+              <option value="">読み込み中...</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span>車番</span>
+            <select id="vehicleSelect">
+              <option value="">読み込み中...</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span>対象月</span>
+            <select id="monthSelect">
+              <option value="">読み込み中...</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section class="points-summary adjustment-summary" aria-labelledby="currentPointsHeading">
+        <div class="summary-copy">
+          <p id="currentPointsHeading" class="summary-label">現在ポイント</p>
+          <p id="currentPointsValue" class="points-value">--</p>
+          <p id="currentPointsMeta" class="status-text">まだ対象を選択していません。</p>
+        </div>
+
+        <div class="month-overview" aria-label="月内データ概要">
+          <div class="overview-item">
+            <span>日次点検</span>
+            <strong id="overviewDaily">--</strong>
+          </div>
+          <div class="overview-item">
+            <span>月次タイヤ点検</span>
+            <strong id="overviewTire">--</strong>
+          </div>
+          <div class="overview-item">
+            <span>ポイントイベント</span>
+            <strong id="overviewEvents">--</strong>
+          </div>
+          <div class="overview-item">
+            <span>対象月ポイント</span>
+            <strong id="overviewMonthPoints">--</strong>
+          </div>
+        </div>
+      </section>
+
+      <section class="adjustment-section" aria-labelledby="eventsHeading">
+        <div class="section-head">
+          <h2 id="eventsHeading">削除対象一覧</h2>
+        </div>
+
+        <div class="table-wrap">
+          <table class="event-table">
+            <thead>
+              <tr>
+                <th>選択</th>
+                <th>日付</th>
+                <th>種別</th>
+                <th>ポイント</th>
+                <th>識別情報</th>
+              </tr>
+            </thead>
+            <tbody id="eventHistoryBody">
+              <tr>
+                <td colspan="5">対象を選択してください。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div class="button-row">
+        <button id="reviewButton" class="mini-button primary" type="button">関連データを確認</button>
+        <p id="statusText" class="status-text" aria-live="polite"></p>
+      </div>
+
+      <section id="reviewSection" class="adjustment-section review-section" aria-labelledby="reviewHeading" hidden>
+        <div class="section-head">
+          <h2 id="reviewHeading">削除前確認</h2>
+          <p>整合性がOKの場合のみ削除を実行できます。</p>
+        </div>
+
+        <div class="review-grid">
+          <section class="review-panel" aria-labelledby="relatedHeading">
+            <h3 id="relatedHeading">関連データ</h3>
+            <ul id="relatedList" class="review-list"></ul>
+          </section>
+
+          <section class="review-panel" aria-labelledby="planHeading">
+            <h3 id="planHeading">削除予定</h3>
+            <ul id="deletePlanList" class="review-list"></ul>
+          </section>
+        </div>
+
+        <section class="review-panel" aria-labelledby="integrityHeading">
+          <h3 id="integrityHeading">整合性</h3>
+          <ul id="integrityList" class="review-list"></ul>
+          <p id="summaryChangeText" class="summary-change"></p>
+        </section>
+
+        <div class="danger-zone">
+          <div>
+            <strong>この操作は元に戻せません。</strong>
+            <p>実行前に削除対象とポイント変化を必ず確認してください。</p>
+          </div>
+          <button id="executeButton" class="mini-button danger" type="button" disabled>削除を実行</button>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const versionSync = window.SinyuubuturyuuPcVersion || null;
+      const version = window.__SINYUUBUTURYUU_PC_VERSION__
+        || (versionSync ? versionSync.getVersion("20260404a") : "20260404a");
+      if (!("serviceWorker" in navigator)) {
+        return;
+      }
+
+      window.addEventListener("load", function () {
+        navigator.serviceWorker.register("../sw.js?v=" + version, {
+          updateViaCache: "none"
+        }).then(function (registration) {
+          return registration.update();
+        }).catch(function (error) {
+          console.warn("Failed to register service worker:", error);
+        });
+      });
+    })();
+  </script>
+  <script src="../launcher-window.js?v=20260330a"></script>
+  <script>
+    (function () {
+      const topBackLink = document.querySelector(".back-link");
+
+      if (window.launcherWindow) {
+        window.launcherWindow.maximizeCurrentWindowIfRequested();
+        window.launcherWindow.bindReturnToLauncher(topBackLink);
+      }
+    })();
+  </script>
+  <script src="../shared-settings.js?v=20260330a"></script>
+  <script src="../getujitiretenkenhyou-pc/firebase/firebase-config.js?v=20260404b"></script>
+  <script src="./firebase-config.js?v=20260404b"></script>
+  <script src="../auth/firebase-auth.js?v=20260404b"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
+  <script>
+    (function () {
+      const version = window.__SINYUUBUTURYUU_PC_VERSION__
+        || (window.SinyuubuturyuuPcVersion ? window.SinyuubuturyuuPcVersion.getVersion("20260404b") : "20260404b");
+      const launcherUrl = new URL("../index.html", window.location.href);
+      launcherUrl.searchParams.set("returnTo", window.location.href);
+
+      const authApi = window.DevFirebaseAuth;
+      if (!authApi || typeof authApi.requireUser !== "function") {
+        console.warn("Auth bootstrap was not available.");
+        window.location.replace(launcherUrl.toString());
+        return;
+      }
+
+      authApi.requireUser({ redirectTo: launcherUrl.toString(), waitMs: 5000 }).then(function (user) {
+        if (!user) {
+          return;
+        }
+        loadScript();
+      }).catch(function (error) {
+        console.warn("Auth bootstrap failed:", error);
+        window.location.replace(launcherUrl.toString());
+      });
+
+      function loadScript() {
+        const script = document.createElement("script");
+        script.src = "./data-adjustment.js?v=" + version;
+        document.body.appendChild(script);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.js
+++ b/sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.js
@@ -1,0 +1,1612 @@
+(function () {
+  "use strict";
+
+  const sharedSettings = window.SharedAppSettings || null;
+  const referenceConfig = window.APP_FIREBASE_DIRECTORY_CONFIG || window.APP_FIREBASE_CONFIG || null;
+  const referenceSyncOptions = window.APP_FIREBASE_DIRECTORY_SYNC_OPTIONS || window.APP_FIREBASE_SYNC_OPTIONS || {};
+  const pointsConfig = window.DRIVER_POINTS_FIREBASE_CONFIG || null;
+  const pointsSettings = window.DRIVER_POINTS_FIREBASE_SETTINGS || {};
+  const SERVER_GET_OPTIONS = Object.freeze({ source: "server" });
+  const DAILY_COLLECTION = "getujinitijyoutenkenhyou";
+  const TIRE_COLLECTION = "getujitiretenkenhyou";
+  const LOG_COLLECTION = "admin_data_adjustment_logs";
+  const SUMMARY_KIND = "driver_points_summary";
+  const EVENT_KIND = "driver_points_event";
+  const DAILY_SOURCE = "dailyInspection";
+  const TIRE_SOURCE = "monthlyTireInspection";
+
+  const optionsDocRefs = Object.freeze({
+    vehicles: {
+      collection: referenceSyncOptions.collection || "syainmeibo",
+      id: "monthly_tire_company_settings_backup_vehicles_slot1"
+    },
+    drivers: {
+      collection: referenceSyncOptions.collection || "syainmeibo",
+      id: "monthly_tire_company_settings_backup_drivers_slot1"
+    }
+  });
+
+  const elements = {
+    driverSelect: document.getElementById("driverSelect"),
+    vehicleSelect: document.getElementById("vehicleSelect"),
+    monthSelect: document.getElementById("monthSelect"),
+    reviewButton: document.getElementById("reviewButton"),
+    executeButton: document.getElementById("executeButton"),
+    currentPointsValue: document.getElementById("currentPointsValue"),
+    currentPointsMeta: document.getElementById("currentPointsMeta"),
+    overviewDaily: document.getElementById("overviewDaily"),
+    overviewTire: document.getElementById("overviewTire"),
+    overviewEvents: document.getElementById("overviewEvents"),
+    overviewMonthPoints: document.getElementById("overviewMonthPoints"),
+    eventHistoryBody: document.getElementById("eventHistoryBody"),
+    reviewSection: document.getElementById("reviewSection"),
+    relatedList: document.getElementById("relatedList"),
+    deletePlanList: document.getElementById("deletePlanList"),
+    integrityList: document.getElementById("integrityList"),
+    summaryChangeText: document.getElementById("summaryChangeText"),
+    statusText: document.getElementById("statusText")
+  };
+
+  const state = {
+    optionSourceReady: false,
+    loading: false,
+    executing: false,
+    loadToken: 0,
+    referenceDb: null,
+    pointsDb: null,
+    activeSchema: null,
+    vehicleOptions: [],
+    driverOptions: [],
+    currentSummary: null,
+    allEvents: [],
+    monthEvents: [],
+    dailyRecords: [],
+    tireRecords: [],
+    monthsWithData: new Set(),
+    selectedEventId: "",
+    review: null
+  };
+
+  bindEvents();
+  void initialize();
+
+  function bindEvents() {
+    elements.driverSelect.addEventListener("change", handleSelectionChanged);
+    elements.vehicleSelect.addEventListener("change", handleSelectionChanged);
+    elements.monthSelect.addEventListener("change", handleSelectionChanged);
+    elements.reviewButton.addEventListener("click", function () {
+      buildAndRenderReview();
+    });
+    elements.executeButton.addEventListener("click", function () {
+      void executeReview();
+    });
+    elements.eventHistoryBody.addEventListener("change", function (event) {
+      const target = event.target;
+      if (!target || target.name !== "eventChoice") {
+        return;
+      }
+      state.selectedEventId = normalizeText(target.value);
+      resetReview();
+      syncButtons();
+    });
+  }
+
+  async function initialize() {
+    setStatus("候補と Firebase 接続を読み込んでいます...");
+    syncButtons();
+    renderMonthOptions();
+
+    try {
+      await Promise.all([
+        loadSelectableOptions(),
+        initializePointsDb()
+      ]);
+      state.optionSourceReady = true;
+      setStatus("乗務員、車番、対象月を選択してください。");
+    } catch (error) {
+      console.warn("Failed to initialize data adjustment page:", error);
+      setStatus("初期化に失敗しました: " + formatError(error), true);
+    } finally {
+      syncButtons();
+    }
+  }
+
+  async function loadSelectableOptions() {
+    const localOptions = getLocalOptions();
+    let cloudVehicles = [];
+    let cloudDrivers = [];
+
+    if (referenceConfig && window.firebase) {
+      try {
+        state.referenceDb = await ensureDb(referenceConfig, {
+          useAnonymousAuth: referenceSyncOptions.useAnonymousAuth !== false
+        }, "shared-settings-reference");
+
+        const snapshots = await Promise.all([
+          state.referenceDb.collection(optionsDocRefs.vehicles.collection).doc(optionsDocRefs.vehicles.id).get(),
+          state.referenceDb.collection(optionsDocRefs.drivers.collection).doc(optionsDocRefs.drivers.id).get()
+        ]);
+
+        cloudVehicles = getStringArray(snapshots[0].exists ? snapshots[0].data() : null);
+        cloudDrivers = getStringArray(snapshots[1].exists ? snapshots[1].data() : null);
+      } catch (error) {
+        console.warn("Failed to load shared options from Firebase:", error);
+      }
+    }
+
+    state.vehicleOptions = buildVehicleOptions(localOptions.vehicles, cloudVehicles);
+    state.driverOptions = buildDriverOptions(localOptions.drivers, cloudDrivers);
+    renderOptions(elements.vehicleSelect, state.vehicleOptions, "車番を選択");
+    renderOptions(elements.driverSelect, state.driverOptions, "乗務員を選択");
+  }
+
+  async function initializePointsDb() {
+    if (!pointsConfig || !window.firebase) {
+      throw new Error("driver_points_config_missing");
+    }
+    state.pointsDb = await ensureDb(pointsConfig, pointsSettings, pointsSettings.appName || "driver-points-app");
+  }
+
+  async function ensureDb(config, settings, appName) {
+    const app = getOrCreateFirebaseApp(config, appName);
+    const auth = app.auth();
+    const authApi = window.DevFirebaseAuth;
+
+    if (authApi && typeof authApi.ensureCompatUser === "function") {
+      await authApi.ensureCompatUser(auth, { waitMs: 5000 });
+    } else if (!auth.currentUser) {
+      throw new Error("ログインしてください。");
+    }
+
+    return app.firestore();
+  }
+
+  function getOrCreateFirebaseApp(config, appName) {
+    const existingApp = window.firebase.apps.find(function (app) {
+      return app.name === appName;
+    });
+    return existingApp || window.firebase.initializeApp(config, appName);
+  }
+
+  function getLocalOptions() {
+    if (!sharedSettings || typeof sharedSettings.ensureState !== "function") {
+      return { vehicles: [], drivers: [] };
+    }
+    const sharedState = sharedSettings.ensureState();
+    return {
+      vehicles: Array.isArray(sharedState.vehicles) ? sharedState.vehicles : [],
+      drivers: Array.isArray(sharedState.drivers) ? sharedState.drivers : []
+    };
+  }
+
+  function buildVehicleOptions() {
+    const unique = [];
+    const seen = new Set();
+    Array.from(arguments).forEach(function (values) {
+      (values || []).forEach(function (value) {
+        const label = normalizeText(value);
+        const key = normalizeVehicleKey(label);
+        if (!label || !key || seen.has(key)) {
+          return;
+        }
+        seen.add(key);
+        unique.push({ value: label, label: label, key: key });
+      });
+    });
+    return unique.sort(function (left, right) {
+      return left.label.localeCompare(right.label, "ja", { numeric: true, sensitivity: "base" });
+    });
+  }
+
+  function buildDriverOptions() {
+    const mergedDrivers = [];
+    Array.from(arguments).forEach(function (values) {
+      (values || []).forEach(function (value) {
+        const rawValue = normalizeText(value);
+        if (rawValue) {
+          mergedDrivers.push(rawValue);
+        }
+      });
+    });
+
+    const orderedDrivers = sharedSettings && typeof sharedSettings.normalizeDrivers === "function"
+      ? sharedSettings.normalizeDrivers(mergedDrivers)
+      : mergedDrivers;
+    const options = [];
+    const seen = new Set();
+
+    orderedDrivers.forEach(function (value) {
+      const rawValue = normalizeText(value);
+      const label = normalizeDriverName(value);
+      const key = normalizeDriverKey(value);
+      if (!label || !key || seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      options.push({ value: rawValue || label, label: label, key: key });
+    });
+
+    return options;
+  }
+
+  function renderOptions(select, options, placeholder) {
+    select.innerHTML = "";
+    const placeholderOption = document.createElement("option");
+    placeholderOption.value = "";
+    placeholderOption.textContent = placeholder;
+    select.appendChild(placeholderOption);
+
+    options.forEach(function (option) {
+      const optionElement = document.createElement("option");
+      optionElement.value = option.value;
+      optionElement.textContent = option.label;
+      select.appendChild(optionElement);
+    });
+  }
+
+  function renderMonthOptions() {
+    const today = new Date();
+    const currentFiscalYear = today.getMonth() + 1 >= 4 ? today.getFullYear() : today.getFullYear() - 1;
+    const months = [];
+    for (let year = currentFiscalYear - 2; year <= currentFiscalYear + 1; year += 1) {
+      for (let month = 4; month <= 15; month += 1) {
+        const displayYear = month <= 12 ? year : year + 1;
+        const displayMonth = month <= 12 ? month : month - 12;
+        const value = displayYear + "-" + String(displayMonth).padStart(2, "0");
+        months.push({ value: value, label: displayYear + "年" + displayMonth + "月" });
+      }
+    }
+
+    elements.monthSelect.innerHTML = "";
+    months.forEach(function (month) {
+      const option = document.createElement("option");
+      option.value = month.value;
+      option.dataset.baseLabel = month.label;
+      option.textContent = month.label;
+      elements.monthSelect.appendChild(option);
+    });
+    elements.monthSelect.value = buildLocalMonthKey(today);
+  }
+
+  function updateMonthOptionMarkers(monthsWithData) {
+    const selectedValue = elements.monthSelect.value;
+    const dataMonths = monthsWithData instanceof Set ? monthsWithData : new Set();
+
+    Array.from(elements.monthSelect.options).forEach(function (option) {
+      const baseLabel = option.dataset.baseLabel || option.textContent.replace(/^●\s*/, "");
+      option.dataset.baseLabel = baseLabel;
+      option.textContent = dataMonths.has(option.value) ? "● " + baseLabel : baseLabel;
+    });
+
+    elements.monthSelect.value = selectedValue;
+  }
+
+  function handleSelectionChanged() {
+    state.selectedEventId = "";
+    resetReview();
+    syncButtons();
+
+    if (!hasBaseSelection()) {
+      resetLoadedData();
+      renderContext();
+      setStatus("乗務員、車番、対象月を選択してください。");
+      return;
+    }
+
+    void loadContext();
+  }
+
+  async function loadContext() {
+    const token = ++state.loadToken;
+    const vehicle = normalizeText(elements.vehicleSelect.value);
+    const driverOption = getSelectedDriverOption();
+    const month = normalizeMonthKey(elements.monthSelect.value);
+    if (!vehicle || !driverOption || !month || !state.pointsDb) {
+      return;
+    }
+
+    state.loading = true;
+    setStatus("対象データを読み込んでいます...");
+    syncButtons();
+
+    try {
+      const schema = await resolveSchema(false);
+      const summary = await findPointSummaryRecord(schema, vehicle, driverOption);
+      const allEvents = await loadPointEvents(schema, vehicle, driverOption);
+      const dailyRecords = await loadDailyRecords(vehicle, driverOption, month);
+      const tireRecords = await loadTireRecords(vehicle, driverOption, month);
+      const monthsWithData = await loadMonthsWithData(vehicle, driverOption, allEvents, dailyRecords, tireRecords);
+
+      if (token !== state.loadToken) {
+        return;
+      }
+
+      state.activeSchema = schema;
+      state.currentSummary = summary;
+      state.allEvents = allEvents;
+      state.monthEvents = allEvents.filter(function (eventRecord) {
+        return getEventMonth(eventRecord.data) === month;
+      }).sort(compareEventRecords);
+      state.dailyRecords = dailyRecords;
+      state.tireRecords = tireRecords;
+      state.monthsWithData = monthsWithData;
+
+      renderContext();
+      setStatus("関連データを読み込みました。");
+    } catch (error) {
+      console.warn("Failed to load adjustment context:", error);
+      resetLoadedData();
+      renderContext();
+      setStatus("対象データの読み込みに失敗しました: " + formatError(error), true);
+    } finally {
+      if (token === state.loadToken) {
+        state.loading = false;
+        syncButtons();
+      }
+    }
+  }
+
+  async function resolveSchema(forceReloadSchema) {
+    if (!forceReloadSchema && state.activeSchema) {
+      return state.activeSchema;
+    }
+    const collectionCandidates = buildCollectionCandidates();
+
+    let firstUsableSchema = null;
+    for (const collectionName of collectionCandidates) {
+      const schema = await inspectCollection(collectionName);
+      if (!schema) {
+        continue;
+      }
+      if (!firstUsableSchema) {
+        firstUsableSchema = schema;
+      }
+      if (schema.detectedFromDocuments) {
+        state.activeSchema = schema;
+        return schema;
+      }
+    }
+
+    state.activeSchema = firstUsableSchema || buildFallbackSchema(pointsSettings.preferredCollection || "driver-points");
+    return state.activeSchema;
+  }
+
+  function buildCollectionCandidates() {
+    const candidates = [];
+    const seen = new Set();
+    const preferredCollection = normalizeText(pointsSettings.preferredCollection);
+    if (preferredCollection) {
+      candidates.push(preferredCollection);
+      seen.add(preferredCollection);
+    }
+    (pointsSettings.collectionCandidates || []).forEach(function (value) {
+      const normalizedValue = normalizeText(value);
+      if (!normalizedValue || seen.has(normalizedValue)) {
+        return;
+      }
+      seen.add(normalizedValue);
+      candidates.push(normalizedValue);
+    });
+    return candidates.length ? candidates : ["driver-points"];
+  }
+
+  async function inspectCollection(collectionName) {
+    try {
+      const snapshot = await getServerQuerySnapshot(state.pointsDb.collection(collectionName).limit(100));
+      if (snapshot.empty) {
+        return buildFallbackSchema(collectionName);
+      }
+      const docs = snapshot.docs.map(function (docSnapshot) {
+        return { id: docSnapshot.id, data: docSnapshot.data() || {} };
+      });
+      return inferSchema(collectionName, docs);
+    } catch (error) {
+      console.warn("Failed to inspect point collection:", collectionName, error);
+      return null;
+    }
+  }
+
+  function inferSchema(collectionName, docs) {
+    const sampleFields = new Set();
+    docs.forEach(function (entry) {
+      Object.keys(entry.data || {}).forEach(function (fieldName) {
+        sampleFields.add(fieldName);
+      });
+    });
+
+    return {
+      collectionName: collectionName,
+      vehicleField: inferFieldName(sampleFields, pointsSettings.vehicleFieldCandidates, /vehicle|car|truck/i) || "vehicleNumber",
+      driverField: inferFieldName(sampleFields, pointsSettings.driverFieldCandidates, /driver|name|staff|employee/i) || "driverKey",
+      pointsField: inferFieldName(sampleFields, pointsSettings.pointsFieldCandidates, /point|score/i) || "totalPoints",
+      updatedAtField: inferFieldName(sampleFields, pointsSettings.updatedAtFieldCandidates, /updated|created|modified/i) || "updatedAt",
+      docIdPatterns: Array.isArray(pointsSettings.docIdPatterns) ? pointsSettings.docIdPatterns.slice() : [],
+      detectedFromDocuments: true
+    };
+  }
+
+  function inferFieldName(fieldNames, candidates, fallbackPattern) {
+    for (const candidate of candidates || []) {
+      if (fieldNames.has(candidate)) {
+        return candidate;
+      }
+    }
+    for (const fieldName of fieldNames) {
+      if (fallbackPattern.test(fieldName)) {
+        return fieldName;
+      }
+    }
+    return "";
+  }
+
+  function buildFallbackSchema(collectionName) {
+    return {
+      collectionName: collectionName,
+      vehicleField: "vehicleNumber",
+      driverField: "driverKey",
+      pointsField: "totalPoints",
+      updatedAtField: "updatedAt",
+      docIdPatterns: Array.isArray(pointsSettings.docIdPatterns) ? pointsSettings.docIdPatterns.slice() : [],
+      detectedFromDocuments: false
+    };
+  }
+
+  async function findPointSummaryRecord(schema, vehicle, driverOption) {
+    const collectionRef = state.pointsDb.collection(schema.collectionName);
+    const identity = buildSelectionIdentity(driverOption.label, vehicle);
+    const directDoc = await getServerDocumentSnapshot(collectionRef.doc(buildSummaryDocId(identity)));
+    if (directDoc.exists) {
+      const record = { id: directDoc.id, ref: directDoc.ref, data: directDoc.data() || {} };
+      if (recordMatchesSelection(record, schema, vehicle, driverOption)) {
+        return record;
+      }
+    }
+
+    const summaryKindValue = normalizeText(pointsSettings.summaryKindValue) || SUMMARY_KIND;
+    try {
+      const snapshot = await getServerQuerySnapshot(collectionRef.where("kind", "==", summaryKindValue).limit(600));
+      const candidates = snapshot.docs.map(toRecord).filter(function (record) {
+        return isSummaryRecord(record) && recordMatchesSelection(record, schema, vehicle, driverOption);
+      });
+      return pickLatestRecord(candidates, schema);
+    } catch (error) {
+      console.warn("Summary query failed:", error);
+    }
+
+    const fallbackSnapshot = await getServerQuerySnapshot(collectionRef.limit(600));
+    const candidates = fallbackSnapshot.docs.map(toRecord).filter(function (record) {
+      return isSummaryRecord(record) && recordMatchesSelection(record, schema, vehicle, driverOption);
+    });
+    return pickLatestRecord(candidates, schema);
+  }
+
+  async function loadPointEvents(schema, vehicle, driverOption) {
+    const collectionRef = state.pointsDb.collection(schema.collectionName);
+    let docs = [];
+    try {
+      const snapshot = await getServerQuerySnapshot(collectionRef.where("kind", "==", EVENT_KIND).limit(1000));
+      docs = snapshot.docs;
+    } catch (error) {
+      console.warn("Point event query failed, falling back to collection scan:", error);
+      const snapshot = await getServerQuerySnapshot(collectionRef.limit(1000));
+      docs = snapshot.docs;
+    }
+
+    return docs.map(toRecord).filter(function (record) {
+      return isEventRecord(record) && recordMatchesSelection(record, schema, vehicle, driverOption);
+    });
+  }
+
+  async function loadDailyRecords(vehicle, driverOption, month) {
+    let docs = [];
+    try {
+      const snapshot = await getServerQuerySnapshot(state.pointsDb.collection(DAILY_COLLECTION).where("month", "==", month).limit(300));
+      docs = snapshot.docs;
+    } catch (error) {
+      console.warn("Daily inspection month query failed:", error);
+      const snapshot = await getServerQuerySnapshot(state.pointsDb.collection(DAILY_COLLECTION).limit(500));
+      docs = snapshot.docs;
+    }
+
+    return docs.map(toRecord).filter(function (record) {
+      return normalizeMonthKey(record.data.month) === month
+        && dailyRecordMatchesSelection(record.data, vehicle, driverOption);
+    });
+  }
+
+  async function loadTireRecords(vehicle, driverOption, month) {
+    const snapshot = await getServerQuerySnapshot(state.pointsDb.collection(TIRE_COLLECTION).limit(700));
+    return snapshot.docs.map(toRecord).filter(function (record) {
+      return getTireRecordMonth(record.data) === month
+        && tireRecordMatchesSelection(record.data, vehicle, driverOption);
+    });
+  }
+
+  async function loadMonthsWithData(vehicle, driverOption, events, dailyRecords, tireRecords) {
+    const months = new Set();
+
+    (events || []).forEach(function (eventRecord) {
+      const month = getEventMonth(eventRecord.data);
+      if (month) {
+        months.add(month);
+      }
+    });
+
+    (dailyRecords || []).forEach(function (record) {
+      const month = normalizeMonthKey(record.data && record.data.month);
+      if (month && dailyRecordHasAnyContent(record.data)) {
+        months.add(month);
+      }
+    });
+
+    (tireRecords || []).forEach(function (record) {
+      const month = getTireRecordMonth(record.data);
+      if (month) {
+        months.add(month);
+      }
+    });
+
+    await Promise.all([
+      addDailyDataMonths(months, vehicle, driverOption),
+      addTireDataMonths(months, vehicle, driverOption)
+    ]);
+
+    return months;
+  }
+
+  async function addDailyDataMonths(months, vehicle, driverOption) {
+    try {
+      const snapshot = await getServerQuerySnapshot(state.pointsDb.collection(DAILY_COLLECTION).limit(1000));
+      snapshot.docs.map(toRecord).forEach(function (record) {
+        const month = normalizeMonthKey(record.data && record.data.month);
+        if (month && dailyRecordMatchesSelection(record.data, vehicle, driverOption) && dailyRecordHasAnyContent(record.data)) {
+          months.add(month);
+        }
+      });
+    } catch (error) {
+      console.warn("Failed to collect daily inspection data months:", error);
+    }
+  }
+
+  async function addTireDataMonths(months, vehicle, driverOption) {
+    try {
+      const snapshot = await getServerQuerySnapshot(state.pointsDb.collection(TIRE_COLLECTION).limit(1000));
+      snapshot.docs.map(toRecord).forEach(function (record) {
+        const month = getTireRecordMonth(record.data);
+        if (month && tireRecordMatchesSelection(record.data, vehicle, driverOption)) {
+          months.add(month);
+        }
+      });
+    } catch (error) {
+      console.warn("Failed to collect monthly tire data months:", error);
+    }
+  }
+
+  function toRecord(docSnapshot) {
+    return {
+      id: docSnapshot.id,
+      ref: docSnapshot.ref,
+      data: docSnapshot.data() || {}
+    };
+  }
+
+  function recordMatchesSelection(record, schema, vehicle, driverOption) {
+    const data = record && record.data ? record.data : {};
+    return dataVehicleMatches(data, vehicle, [schema.vehicleField].concat(pointsSettings.vehicleFieldCandidates || []))
+      && dataDriverMatches(data, driverOption, [schema.driverField].concat(pointsSettings.driverFieldCandidates || []));
+  }
+
+  function dailyRecordMatchesSelection(data, vehicle, driverOption) {
+    return dataVehicleMatches(data, vehicle, [
+      "vehicle", "vehicleRaw", "vehicleDisplay", "vehicleAliases", "vehicleNormalized", "vehicleNumber", "vehicleKey"
+    ]) && dataDriverMatches(data, driverOption, [
+      "driver", "driverRaw", "driverDisplay", "driverAliases", "driverNormalized", "driverName", "driverKey"
+    ]);
+  }
+
+  function tireRecordMatchesSelection(data, vehicle, driverOption) {
+    return dataVehicleMatches(data, vehicle, ["vehicleNumber", "vehicle", "vehicleKey", "vehicleNo"])
+      && dataDriverMatches(data, driverOption, ["driverName", "driver", "driverKey", "driverRaw", "driverDisplay"]);
+  }
+
+  function dataVehicleMatches(data, vehicle, fieldNames) {
+    const targetKey = normalizeVehicleKey(vehicle);
+    const values = collectNormalizedFieldValues(data, uniqueFieldNames(fieldNames), normalizeVehicleKey);
+    return values.includes(targetKey);
+  }
+
+  function dataDriverMatches(data, driverOption, fieldNames) {
+    if (!driverOption) {
+      return false;
+    }
+    const keys = collectNormalizedFieldValues(data, uniqueFieldNames(fieldNames), normalizeDriverKey);
+    return keys.includes(driverOption.key) || keys.includes(normalizeDriverKey(driverOption.label));
+  }
+
+  function renderContext() {
+    const schema = state.activeSchema || buildFallbackSchema(pointsSettings.preferredCollection || "driver-points");
+    const currentPoints = state.currentSummary ? getRecordPoints(state.currentSummary, schema) : 0;
+    const monthPointTotal = calculateEventBreakdown(state.monthEvents).total;
+    const dailyDays = collectDailyDays(state.dailyRecords);
+
+    elements.currentPointsValue.textContent = hasBaseSelection() ? String(currentPoints) : "--";
+    elements.currentPointsMeta.textContent = state.currentSummary
+      ? "ポイントサマリーを読み込みました。"
+      : (hasBaseSelection() ? "ポイントサマリーは未作成です。" : "まだ対象を選択していません。");
+    updateMonthOptionMarkers(hasBaseSelection() ? state.monthsWithData : new Set());
+    elements.overviewDaily.textContent = hasBaseSelection() ? String(dailyDays.length) + "日分" : "--";
+    elements.overviewTire.textContent = hasBaseSelection() ? (state.tireRecords.length ? "あり" : "なし") : "--";
+    elements.overviewEvents.textContent = hasBaseSelection() ? String(state.monthEvents.length) + "件" : "--";
+    elements.overviewMonthPoints.textContent = hasBaseSelection() ? formatSignedPoints(monthPointTotal) : "--";
+    renderEventHistory();
+    syncButtons();
+  }
+
+  function renderEventHistory() {
+    if (!hasBaseSelection()) {
+      elements.eventHistoryBody.innerHTML = '<tr><td colspan="5">対象を選択してください。</td></tr>';
+      return;
+    }
+    if (!state.monthEvents.length) {
+      elements.eventHistoryBody.innerHTML = '<tr><td colspan="5">対象月のポイントイベントはありません。</td></tr>';
+      return;
+    }
+
+    elements.eventHistoryBody.innerHTML = state.monthEvents.map(function (eventRecord) {
+      const data = eventRecord.data || {};
+      const checked = state.selectedEventId === eventRecord.id ? " checked" : "";
+      return [
+        "<tr>",
+        '<td><input type="radio" name="eventChoice" value="' + escapeHtml(eventRecord.id) + '"' + checked + "></td>",
+        "<td>" + escapeHtml(getEventDateLabel(data)) + "</td>",
+        '<td><span class="event-source">' + escapeHtml(getEventSourceLabel(data.source)) + "</span></td>",
+        '<td>' + escapeHtml(formatSignedPoints(getNumericValue(data.points))) + "</td>",
+        '<td><div class="event-meta">'
+          + '<span>ID: ' + escapeHtml(eventRecord.id) + "</span>"
+          + '<span>月: ' + escapeHtml(getEventMonth(data) || "-") + " / 日: " + escapeHtml(getEventDay(data) || "-") + "</span>"
+          + '<span>メモ: ' + escapeHtml(normalizeText(data.memo) || "-") + "</span>"
+          + "</div></td>",
+        "</tr>"
+      ].join("");
+    }).join("");
+  }
+
+  function buildAndRenderReview() {
+    resetReview();
+
+    if (!hasBaseSelection()) {
+      setStatus("関連データを確認する前に乗務員、車番、対象月を選択してください。", true);
+      return;
+    }
+    if (state.loading) {
+      setStatus("対象データの読み込み中です。少し待ってから確認してください。", true);
+      return;
+    }
+
+    state.review = buildReview();
+    renderReview();
+    syncButtons();
+  }
+
+  function buildReview() {
+    const vehicle = normalizeText(elements.vehicleSelect.value);
+    const driverOption = getSelectedDriverOption();
+    const month = normalizeMonthKey(elements.monthSelect.value);
+    const schema = state.activeSchema || buildFallbackSchema(pointsSettings.preferredCollection || "driver-points");
+    const summaryBefore = state.currentSummary ? getRecordPoints(state.currentSummary, schema) : 0;
+    const beforeBreakdown = calculateEventBreakdown(state.allEvents);
+
+    const review = {
+      targetType: "",
+      vehicle: vehicle,
+      driverOption: driverOption,
+      month: month,
+      day: null,
+      summaryBefore: summaryBefore,
+      summaryAfter: summaryBefore,
+      eventTotalBefore: beforeBreakdown.total,
+      eventTotalAfter: beforeBreakdown.total,
+      relatedItems: [],
+      deleteItems: [],
+      integrityItems: [],
+      errors: [],
+      warnings: [],
+      deleteEventIds: [],
+      deleteTireRecords: [],
+      deleteDailyDays: [],
+      summaryPayload: null,
+      deleteSummaryAfter: false,
+      logAction: "",
+      canExecute: false,
+      executeLabel: "削除を実行"
+    };
+
+    buildSelectedEventReview(review);
+
+    if (summaryBefore !== beforeBreakdown.total) {
+      review.errors.push(
+        "現在ポイントとイベント合計が一致していません。安全のため削除できません。Firebase の履歴とサマリーを確認してください。"
+      );
+    }
+
+    const remainingEvents = state.allEvents.filter(function (eventRecord) {
+      return !review.deleteEventIds.includes(eventRecord.id);
+    });
+    const afterBreakdown = calculateEventBreakdown(remainingEvents);
+    review.eventTotalAfter = afterBreakdown.total;
+    review.summaryAfter = afterBreakdown.total;
+    review.deleteSummaryAfter = remainingEvents.length === 0;
+    review.summaryPayload = buildSummaryPayload(schema, review, afterBreakdown);
+
+    review.integrityItems = buildIntegrityMessages(review);
+    review.canExecute = review.errors.length === 0
+      && Boolean(review.summaryPayload)
+      && (review.deleteEventIds.length > 0 || review.deleteTireRecords.length > 0 || review.deleteDailyDays.length > 0);
+
+    return review;
+  }
+
+  function buildSelectedEventReview(review) {
+    const selectedEvent = state.monthEvents.find(function (eventRecord) {
+      return eventRecord.id === state.selectedEventId;
+    });
+    if (!selectedEvent) {
+      review.errors.push("削除したい履歴を一覧から1件選択してください。");
+      return;
+    }
+
+    const source = normalizeText(selectedEvent.data && selectedEvent.data.source);
+    if (source === DAILY_SOURCE) {
+      review.targetType = "dailyInspection";
+      buildDailyReview(review, selectedEvent);
+      return;
+    }
+    if (source === TIRE_SOURCE) {
+      review.targetType = "monthlyTireInspection";
+      buildMonthlyTireReview(review, selectedEvent);
+      return;
+    }
+
+    review.targetType = "pointEvent";
+    buildPointEventReview(review, selectedEvent);
+  }
+
+  function buildDailyReview(review, selectedEvent) {
+    review.logAction = "deleteDailyInspectionWithRelatedPoints";
+    if (!selectedEvent) {
+      review.errors.push("日次点検削除では、対象月のポイントイベント一覧から削除する日付の履歴を1件選択してください。");
+      return;
+    }
+    if (normalizeText(selectedEvent.data && selectedEvent.data.source) !== DAILY_SOURCE) {
+      review.errors.push("日次点検削除では、日次点検のポイントイベントを選択してください。");
+      return;
+    }
+
+    const day = normalizeDayNumber(getEventDay(selectedEvent.data));
+    if (!day) {
+      review.errors.push("選択した日次点検イベントから対象日を判断できません。");
+      return;
+    }
+    review.day = day;
+
+    const dailyRecords = state.dailyRecords.filter(function (record) {
+      return dailyRecordHasDay(record.data, day);
+    });
+    const dailyEvents = state.monthEvents.filter(function (eventRecord) {
+      const data = eventRecord.data || {};
+      return normalizeText(data.source) === DAILY_SOURCE && normalizeDayNumber(getEventDay(data)) === day;
+    });
+
+    review.relatedItems.push("対象日: " + formatMonthLabel(review.month) + " " + day + "日");
+    review.relatedItems.push("日次点検データ: " + dailyRecords.length + "件");
+    review.relatedItems.push("対応ポイントイベント: " + dailyEvents.length + "件");
+
+    if (dailyRecords.length === 0) {
+      review.logAction = "deleteOrphanDailyInspectionPointEvent";
+      review.warnings.push("元の日次点検データが見つからないため、選択したポイントイベントのみ削除します。");
+    } else if (dailyRecords.length > 1) {
+      review.errors.push("対象の日次点検データが複数見つかりました。どれを削除すべきか判断できません。");
+    }
+    if (dailyEvents.length !== 1) {
+      review.errors.push(
+        dailyEvents.length === 0
+          ? "対象の日次点検に対応するポイントイベントが見つかりません。"
+          : "対象の日次点検に対応するポイントイベントが複数あります。どれを削除すべきか判断できません。"
+      );
+    } else if (dailyEvents[0].id !== selectedEvent.id) {
+      review.errors.push("選択された日次点検イベントと、削除候補のイベントが一致しません。");
+    }
+
+    if (dailyRecords.length === 1) {
+      const details = describeDailyDayDetails(dailyRecords[0].data, day);
+      details.forEach(function (detail) {
+        review.relatedItems.push(detail);
+      });
+      review.deleteDailyDays.push({ record: dailyRecords[0], day: day });
+      review.deleteItems.push("日次点検データ: " + dailyRecords[0].id + " の " + day + "日分");
+    }
+    if (dailyEvents.length === 1 && dailyEvents[0].id === selectedEvent.id) {
+      review.deleteEventIds.push(selectedEvent.id);
+      review.deleteItems.push("ポイントイベント: " + selectedEvent.id + " (" + formatSignedPoints(getNumericValue(selectedEvent.data.points)) + ")");
+    }
+  }
+
+  function buildMonthlyTireReview(review, selectedEvent) {
+    review.logAction = "deleteMonthlyTireInspectionWithRelatedPoints";
+    const tireEvents = state.monthEvents.filter(function (eventRecord) {
+      return normalizeText(eventRecord.data && eventRecord.data.source) === TIRE_SOURCE;
+    });
+
+    review.relatedItems.push("対象月: " + formatMonthLabel(review.month));
+    review.relatedItems.push("月次タイヤ点検データ: " + state.tireRecords.length + "件");
+    review.relatedItems.push("対応ポイントイベント: " + tireEvents.length + "件");
+
+    if (state.tireRecords.length === 0) {
+      review.logAction = "deleteOrphanMonthlyTireInspectionPointEvent";
+      review.warnings.push("元の月次タイヤ点検データが見つからないため、選択したポイントイベントのみ削除します。");
+    } else if (state.tireRecords.length > 1) {
+      review.errors.push("対象月の月次タイヤ点検データが複数見つかりました。どれを削除すべきか判断できません。");
+    }
+    if (tireEvents.length !== 1) {
+      review.errors.push(
+        tireEvents.length === 0
+          ? "対象月の月次タイヤ点検に対応するポイントイベントが見つかりません。"
+          : "対象月の月次タイヤ点検に対応するポイントイベントが複数あります。どれを削除すべきか判断できません。"
+      );
+    }
+    if (selectedEvent && tireEvents.length === 1 && tireEvents[0].id !== selectedEvent.id) {
+      review.errors.push("選択された月次タイヤ点検イベントと、削除候補のイベントが一致しません。");
+    }
+
+    if (state.tireRecords.length === 1) {
+      const data = state.tireRecords[0].data || {};
+      review.relatedItems.push("点検日: " + (normalizeText(data.inspectionDate) || "-"));
+      review.deleteTireRecords.push(state.tireRecords[0]);
+      review.deleteItems.push("月次タイヤ点検データ: " + state.tireRecords[0].id);
+    }
+    if (tireEvents.length === 1 && tireEvents[0].id === selectedEvent.id) {
+      review.deleteEventIds.push(tireEvents[0].id);
+      review.deleteItems.push("ポイントイベント: " + tireEvents[0].id + " (" + formatSignedPoints(getNumericValue(tireEvents[0].data.points)) + ")");
+    }
+  }
+
+  function buildPointEventReview(review, selectedEvent) {
+    review.logAction = "deletePointEventOnly";
+    if (!selectedEvent) {
+      review.errors.push("ポイントイベントのみ削除では、履歴一覧から削除するイベントを1件選択してください。");
+      return;
+    }
+
+    const data = selectedEvent.data || {};
+    review.relatedItems.push("選択イベント: " + selectedEvent.id);
+    review.relatedItems.push("種別: " + getEventSourceLabel(data.source));
+    review.relatedItems.push("ポイント: " + formatSignedPoints(getNumericValue(data.points)));
+    review.deleteEventIds.push(selectedEvent.id);
+    review.deleteItems.push("ポイントイベントのみ削除: " + selectedEvent.id);
+
+    if (normalizeText(data.source) === DAILY_SOURCE && sourceDailyDataExists(data)) {
+      review.warnings.push("元の日次点検データが残っている可能性があります。ポイントイベントのみ削除として処理します。");
+    }
+    if (normalizeText(data.source) === TIRE_SOURCE && state.tireRecords.length > 0) {
+      review.warnings.push("元の月次タイヤ点検データが残っている可能性があります。ポイントイベントのみ削除として処理します。");
+    }
+  }
+
+  function buildIntegrityMessages(review) {
+    const messages = [];
+    review.errors.forEach(function (message) {
+      messages.push({ type: "error", text: message });
+    });
+    review.warnings.forEach(function (message) {
+      messages.push({ type: "warning", text: message });
+    });
+
+    if (review.errors.length === 0) {
+      messages.push({ type: "ok", text: "整合性: OK" });
+    } else {
+      messages.push({ type: "error", text: "整合性: NG" });
+    }
+
+    if (review.summaryBefore !== review.eventTotalBefore) {
+      messages.push({
+        type: "error",
+        text: "サマリー " + review.summaryBefore + "pt / イベント合計 " + review.eventTotalBefore + "pt"
+      });
+    } else {
+      messages.push({ type: "ok", text: "サマリーとイベント合計は一致しています。" });
+    }
+
+    return messages;
+  }
+
+  function renderReview() {
+    const review = state.review;
+    if (!review) {
+      return;
+    }
+
+    elements.reviewSection.hidden = false;
+    elements.relatedList.innerHTML = renderReviewItems(review.relatedItems, "");
+    elements.deletePlanList.innerHTML = renderReviewItems(review.deleteItems.length ? review.deleteItems : ["削除予定はありません。"], "");
+    elements.integrityList.innerHTML = review.integrityItems.map(function (item) {
+      return '<li class="' + escapeHtml(item.type) + '">' + escapeHtml(item.text) + "</li>";
+    }).join("");
+    elements.summaryChangeText.textContent = "ポイントサマリー: "
+      + String(review.summaryBefore) + "pt → " + String(review.summaryAfter) + "pt";
+    elements.executeButton.textContent = review.executeLabel || "削除を実行";
+    elements.executeButton.disabled = !review.canExecute || state.executing;
+    setStatus(review.canExecute ? "削除実行前に内容を確認してください。" : "整合性NGまたは実行対象なしのため、実行できません。", !review.canExecute);
+  }
+
+  function renderReviewItems(items, className) {
+    return (items || []).map(function (item) {
+      return '<li class="' + escapeHtml(className || "") + '">' + escapeHtml(item) + "</li>";
+    }).join("");
+  }
+
+  async function executeReview() {
+    const review = state.review;
+    if (!review || !review.canExecute || state.executing) {
+      return;
+    }
+
+    const confirmMessage = [
+      "この操作は元に戻せません。",
+      "対象: " + (review.driverOption ? review.driverOption.label : "-") + " / " + review.vehicle,
+      "月: " + formatMonthLabel(review.month),
+      "ポイント: " + review.summaryBefore + "pt → " + review.summaryAfter + "pt",
+      "",
+      "実行してよろしいですか？"
+    ].join("\n");
+    if (!window.confirm(confirmMessage)) {
+      return;
+    }
+
+    state.executing = true;
+    syncButtons();
+    setStatus("削除処理を実行しています...");
+
+    try {
+      const batch = state.pointsDb.batch();
+      const FieldValue = window.firebase.firestore.FieldValue;
+      const now = FieldValue.serverTimestamp();
+      const schema = state.activeSchema || buildFallbackSchema(pointsSettings.preferredCollection || "driver-points");
+      const summaryRef = getSummaryRef(schema, review);
+
+      review.deleteDailyDays.forEach(function (entry) {
+        batch.update(entry.record.ref, buildDailyDayDeletePayload(entry.day, FieldValue, now));
+      });
+      review.deleteTireRecords.forEach(function (record) {
+        batch.delete(record.ref);
+      });
+      review.deleteEventIds.forEach(function (eventId) {
+        const eventRecord = state.allEvents.find(function (record) {
+          return record.id === eventId;
+        });
+        if (eventRecord) {
+          batch.delete(eventRecord.ref);
+        }
+      });
+      if (review.deleteSummaryAfter) {
+        batch.delete(summaryRef);
+      } else {
+        batch.set(summaryRef, review.summaryPayload, { merge: true });
+      }
+      batch.set(state.pointsDb.collection(LOG_COLLECTION).doc(), buildLogPayload(review, FieldValue));
+
+      await batch.commit();
+      state.review = null;
+      state.selectedEventId = "";
+      elements.reviewSection.hidden = true;
+      setStatus("データ調整を実行し、ログを保存しました。");
+      await loadContext();
+    } catch (error) {
+      console.warn("Failed to execute data adjustment:", error);
+      setStatus("データ調整の実行に失敗しました: " + formatError(error), true);
+    } finally {
+      state.executing = false;
+      syncButtons();
+    }
+  }
+
+  function buildDailyDayDeletePayload(day, FieldValue, now) {
+    const dayKey = String(day);
+    const payload = {
+      updatedAt: now
+    };
+    [
+      "checksByDay",
+      "maintenanceRecordsByDay",
+      "maintenanceNotesByDay",
+      "maintenanceBottomByDay",
+      "holidayFlagsByDay",
+      "isHolidayByDay"
+    ].forEach(function (fieldName) {
+      payload[fieldName + "." + dayKey] = FieldValue.delete();
+    });
+    payload.holidayDays = FieldValue.arrayRemove(day, dayKey);
+    payload.holidays = FieldValue.arrayRemove(dayKey, day);
+    return payload;
+  }
+
+  function buildSummaryPayload(schema, review, breakdown) {
+    const FieldValue = window.firebase.firestore.FieldValue;
+    const payload = {
+      kind: normalizeText(pointsSettings.summaryKindValue) || SUMMARY_KIND,
+      driverKey: review.driverOption ? review.driverOption.key : "",
+      driverName: review.driverOption ? review.driverOption.label : "",
+      driverRaw: review.driverOption ? review.driverOption.value : "",
+      vehicleKey: normalizeVehicleKey(review.vehicle),
+      vehicleNumber: review.vehicle,
+      totalPoints: breakdown.total,
+      dailyInspectionPoints: breakdown.daily,
+      monthlyTirePoints: breakdown.tire,
+      manualAdjustmentPoints: breakdown.manual,
+      otherPoints: breakdown.other,
+      updatedAt: FieldValue.serverTimestamp(),
+      lastSource: "adminDataAdjustment"
+    };
+    payload[schema.vehicleField || "vehicleNumber"] = schema.vehicleField === "vehicleKey"
+      ? normalizeVehicleKey(review.vehicle)
+      : review.vehicle;
+    payload[schema.driverField || "driverKey"] = schema.driverField === "driverKey"
+      ? (review.driverOption ? review.driverOption.key : "")
+      : (review.driverOption ? review.driverOption.label : "");
+
+    const pointsFieldName = resolvePointsFieldName(state.currentSummary ? state.currentSummary.data : null, schema);
+    payload[pointsFieldName] = breakdown.total;
+
+    if (!state.currentSummary) {
+      payload.createdAt = FieldValue.serverTimestamp();
+    }
+    return payload;
+  }
+
+  function getSummaryRef(schema, review) {
+    if (state.currentSummary && state.currentSummary.ref) {
+      return state.currentSummary.ref;
+    }
+    const identity = buildSelectionIdentity(review.driverOption ? review.driverOption.label : "", review.vehicle);
+    return state.pointsDb.collection(schema.collectionName).doc(buildSummaryDocId(identity));
+  }
+
+  function buildLogPayload(review, FieldValue) {
+    const deletedDocs = [];
+    review.deleteDailyDays.forEach(function (entry) {
+      deletedDocs.push({
+        collection: DAILY_COLLECTION,
+        id: entry.record.id,
+        operation: "deleteDay",
+        day: entry.day
+      });
+    });
+    review.deleteTireRecords.forEach(function (record) {
+      deletedDocs.push({ collection: TIRE_COLLECTION, id: record.id, operation: "deleteDoc" });
+    });
+    review.deleteEventIds.forEach(function (eventId) {
+      deletedDocs.push({
+        collection: state.activeSchema ? state.activeSchema.collectionName : "driver-points",
+        id: eventId,
+        operation: "deleteDoc"
+      });
+    });
+
+    return {
+      action: review.logAction,
+      target: {
+        vehicleNumber: review.vehicle,
+        driverName: review.driverOption ? review.driverOption.label : "",
+        driverKey: review.driverOption ? review.driverOption.key : "",
+        month: review.month,
+        day: review.day || null,
+        targetType: review.targetType
+      },
+      deletedDocs: deletedDocs,
+      summaryBefore: review.summaryBefore,
+      summaryAfter: review.summaryAfter,
+      summaryDeleted: review.deleteSummaryAfter === true,
+      eventTotalBefore: review.eventTotalBefore,
+      eventTotalAfter: review.eventTotalAfter,
+      warnings: review.warnings.slice(),
+      createdAt: FieldValue.serverTimestamp(),
+      createdBy: "管理画面"
+    };
+  }
+
+  function resetLoadedData() {
+    state.currentSummary = null;
+    state.allEvents = [];
+    state.monthEvents = [];
+    state.dailyRecords = [];
+    state.tireRecords = [];
+    state.monthsWithData = new Set();
+    state.selectedEventId = "";
+  }
+
+  function resetReview() {
+    state.review = null;
+    elements.reviewSection.hidden = true;
+    elements.executeButton.disabled = true;
+  }
+
+  function syncButtons() {
+    const hasSelection = hasBaseSelection();
+    elements.reviewButton.disabled = !hasSelection || state.loading || state.executing || !state.pointsDb;
+    elements.executeButton.disabled = !state.review || !state.review.canExecute || state.executing;
+  }
+
+  function hasBaseSelection() {
+    return Boolean(
+      normalizeText(elements.vehicleSelect.value)
+        && getSelectedDriverOption()
+        && normalizeMonthKey(elements.monthSelect.value)
+    );
+  }
+
+  function getSelectedDriverOption() {
+    const selectedValue = normalizeText(elements.driverSelect.value);
+    if (!selectedValue) {
+      return null;
+    }
+    return state.driverOptions.find(function (option) {
+      return option.value === selectedValue;
+    }) || null;
+  }
+
+  function collectDailyDays(records) {
+    const days = new Set();
+    (records || []).forEach(function (record) {
+      const data = record.data || {};
+      collectDayKeys(data.checksByDay).forEach(days.add, days);
+      collectDayKeys(data.maintenanceRecordsByDay).forEach(days.add, days);
+      collectDayKeys(data.maintenanceNotesByDay).forEach(days.add, days);
+      collectDayKeys(data.maintenanceBottomByDay).forEach(days.add, days);
+      (data.holidayDays || data.holidays || []).forEach(function (day) {
+        const normalizedDay = normalizeDayNumber(day);
+        if (normalizedDay) {
+          days.add(normalizedDay);
+        }
+      });
+      collectTruthyDayFlags(data.holidayFlagsByDay).forEach(days.add, days);
+      collectTruthyDayFlags(data.isHolidayByDay).forEach(days.add, days);
+    });
+    state.monthEvents.forEach(function (eventRecord) {
+      if (normalizeText(eventRecord.data && eventRecord.data.source) === DAILY_SOURCE) {
+        const day = normalizeDayNumber(getEventDay(eventRecord.data));
+        if (day) {
+          days.add(day);
+        }
+      }
+    });
+    return Array.from(days).sort(function (left, right) {
+      return left - right;
+    });
+  }
+
+  function collectDayKeys(source) {
+    return Object.keys(source || {}).map(normalizeDayNumber).filter(Boolean);
+  }
+
+  function collectTruthyDayFlags(source) {
+    return Object.entries(source || {}).filter(function (entry) {
+      return Boolean(entry[1]);
+    }).map(function (entry) {
+      return normalizeDayNumber(entry[0]);
+    }).filter(Boolean);
+  }
+
+  function dailyRecordHasDay(data, day) {
+    const dayKey = String(day);
+    return Boolean(
+      data
+        && (
+          hasOwn(data.checksByDay, dayKey)
+          || hasOwn(data.maintenanceRecordsByDay, dayKey)
+          || hasOwn(data.maintenanceNotesByDay, dayKey)
+          || hasOwn(data.maintenanceBottomByDay, dayKey)
+          || hasOwn(data.holidayFlagsByDay, dayKey)
+          || hasOwn(data.isHolidayByDay, dayKey)
+          || (Array.isArray(data.holidayDays) && data.holidayDays.map(String).includes(dayKey))
+          || (Array.isArray(data.holidays) && data.holidays.map(String).includes(dayKey))
+        )
+    );
+  }
+
+  function dailyRecordHasAnyContent(data) {
+    if (!data || typeof data !== "object") {
+      return false;
+    }
+    return Boolean(
+      collectDayKeys(data.checksByDay).length
+        || collectDayKeys(data.maintenanceRecordsByDay).length
+        || collectDayKeys(data.maintenanceNotesByDay).length
+        || collectDayKeys(data.maintenanceBottomByDay).length
+        || collectTruthyDayFlags(data.holidayFlagsByDay).length
+        || collectTruthyDayFlags(data.isHolidayByDay).length
+        || (Array.isArray(data.holidayDays) && data.holidayDays.length)
+        || (Array.isArray(data.holidays) && data.holidays.length)
+    );
+  }
+
+  function describeDailyDayDetails(data, day) {
+    const dayKey = String(day);
+    const details = [];
+    if (hasOwn(data.checksByDay, dayKey)) {
+      details.push("点検チェック: あり");
+    }
+    if (hasOwn(data.maintenanceRecordsByDay, dayKey) || hasOwn(data.maintenanceNotesByDay, dayKey)) {
+      details.push("整備記録: あり");
+    }
+    if (hasOwn(data.maintenanceBottomByDay, dayKey)) {
+      details.push("下部の整備管理者印: あり");
+    }
+    if ((Array.isArray(data.holidayDays) && data.holidayDays.map(String).includes(dayKey))
+      || (Array.isArray(data.holidays) && data.holidays.map(String).includes(dayKey))
+      || hasOwn(data.holidayFlagsByDay, dayKey)
+      || hasOwn(data.isHolidayByDay, dayKey)) {
+      details.push("休日設定: あり");
+    }
+    return details.length ? details : ["対象日の詳細データ: あり"];
+  }
+
+  function sourceDailyDataExists(eventData) {
+    const day = normalizeDayNumber(getEventDay(eventData));
+    return state.dailyRecords.some(function (record) {
+      return dailyRecordHasDay(record.data, day);
+    });
+  }
+
+  function getTireRecordMonth(data) {
+    return normalizeMonthKey(data && data.targetMonth)
+      || normalizeMonthKey(normalizeText(data && data.inspectionDate).slice(0, 7));
+  }
+
+  function getEventMonth(data) {
+    return normalizeMonthKey(data && data.month)
+      || normalizeMonthKey(data && data.targetMonth)
+      || normalizeMonthKey(normalizeText(data && data.targetDate).slice(0, 7))
+      || normalizeMonthKey(normalizeText(data && data.inspectionDate).slice(0, 7))
+      || normalizeMonthKey(normalizeText(data && data.sentDate).slice(0, 7))
+      || buildMonthKeyFromTimestamp(data && data.createdAt);
+  }
+
+  function getEventDay(data) {
+    const day = normalizeDayNumber(data && data.day);
+    if (day) {
+      return day;
+    }
+    const targetDate = normalizeText(data && (data.targetDate || data.sentDate || data.inspectionDate));
+    const match = /^\d{4}-\d{2}-(\d{2})/.exec(targetDate);
+    return match ? normalizeDayNumber(match[1]) : 0;
+  }
+
+  function getEventDateLabel(data) {
+    const targetDate = normalizeText(data && (data.targetDate || data.sentDate || data.inspectionDate));
+    if (targetDate) {
+      return targetDate;
+    }
+    const month = getEventMonth(data);
+    const day = getEventDay(data);
+    return month ? month + (day ? "-" + String(day).padStart(2, "0") : "") : "-";
+  }
+
+  function getEventSourceLabel(source) {
+    const value = normalizeText(source);
+    if (value === DAILY_SOURCE) {
+      return "日次点検";
+    }
+    if (value === TIRE_SOURCE) {
+      return "月次タイヤ";
+    }
+    if (value === "manualAdjustment") {
+      return "手動調整";
+    }
+    if (value === "migrationBaseline") {
+      return "移行調整";
+    }
+    return value || "不明";
+  }
+
+  function compareEventRecords(left, right) {
+    const leftDate = getEventDateLabel(left.data);
+    const rightDate = getEventDateLabel(right.data);
+    if (leftDate !== rightDate) {
+      return leftDate.localeCompare(rightDate, "ja", { numeric: true });
+    }
+    return left.id.localeCompare(right.id, "ja", { numeric: true });
+  }
+
+  function calculateEventBreakdown(events) {
+    const breakdown = {
+      total: 0,
+      daily: 0,
+      tire: 0,
+      manual: 0,
+      other: 0
+    };
+    (events || []).forEach(function (eventRecord) {
+      const data = eventRecord.data || {};
+      const points = getNumericValue(data.points);
+      breakdown.total += points;
+      if (normalizeText(data.source) === DAILY_SOURCE) {
+        breakdown.daily += points;
+      } else if (normalizeText(data.source) === TIRE_SOURCE) {
+        breakdown.tire += points;
+      } else if (normalizeText(data.source) === "manualAdjustment") {
+        breakdown.manual += points;
+      } else {
+        breakdown.other += points;
+      }
+    });
+    return breakdown;
+  }
+
+  function isSummaryRecord(record) {
+    const kind = normalizeText(record && record.data && record.data.kind);
+    const id = normalizeText(record && record.id);
+    return kind === (normalizeText(pointsSettings.summaryKindValue) || SUMMARY_KIND)
+      || id.startsWith("driver_points_summary_");
+  }
+
+  function isEventRecord(record) {
+    const kind = normalizeText(record && record.data && record.data.kind);
+    const id = normalizeText(record && record.id);
+    return kind === EVENT_KIND || id.startsWith("driver_points_event_");
+  }
+
+  function pickLatestRecord(records, schema) {
+    const sorted = (records || []).slice().sort(function (left, right) {
+      return getRecordUpdatedAtTime(right.data, schema) - getRecordUpdatedAtTime(left.data, schema);
+    });
+    return sorted[0] || null;
+  }
+
+  function resolvePointsFieldName(source, schema) {
+    const fieldNames = uniqueFieldNames((pointsSettings.pointsFieldCandidates || []).concat(schema && schema.pointsField || "totalPoints"));
+    const safeSource = source && typeof source === "object" ? source : {};
+    for (const fieldName of fieldNames) {
+      const value = safeSource[fieldName];
+      if (typeof value === "number") {
+        return fieldName;
+      }
+      if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
+        return fieldName;
+      }
+    }
+    return fieldNames[0] || "totalPoints";
+  }
+
+  function getRecordPoints(record, schema) {
+    const fieldName = resolvePointsFieldName(record && record.data ? record.data : null, schema);
+    return getNumericValue(record && record.data ? record.data[fieldName] : undefined);
+  }
+
+  function getRecordUpdatedAtTime(source, schema) {
+    const fieldNames = uniqueFieldNames([schema && schema.updatedAtField].concat(pointsSettings.updatedAtFieldCandidates || []));
+    const safeSource = source && typeof source === "object" ? source : {};
+    for (const fieldName of fieldNames) {
+      const time = getTimeValue(safeSource[fieldName]);
+      if (time > 0) {
+        return time;
+      }
+    }
+    return 0;
+  }
+
+  function collectNormalizedFieldValues(source, fieldNames, normalizer) {
+    const values = [];
+    const seen = new Set();
+    const safeSource = source && typeof source === "object" ? source : {};
+    const normalize = typeof normalizer === "function" ? normalizer : normalizeText;
+
+    fieldNames.forEach(function (fieldName) {
+      const rawValue = safeSource[fieldName];
+      const entries = Array.isArray(rawValue) ? rawValue : [rawValue];
+      entries.forEach(function (entry) {
+        const normalizedValue = normalize(entry);
+        if (!normalizedValue || seen.has(normalizedValue)) {
+          return;
+        }
+        seen.add(normalizedValue);
+        values.push(normalizedValue);
+      });
+    });
+
+    return values;
+  }
+
+  function uniqueFieldNames(values) {
+    const unique = [];
+    const seen = new Set();
+    (values || []).forEach(function (value) {
+      const fieldName = normalizeText(value);
+      if (!fieldName || seen.has(fieldName)) {
+        return;
+      }
+      seen.add(fieldName);
+      unique.push(fieldName);
+    });
+    return unique;
+  }
+
+  function getStringArray(source) {
+    if (!source || !Array.isArray(source.values)) {
+      return [];
+    }
+    return source.values.map(normalizeText).filter(Boolean);
+  }
+
+  function buildSelectionIdentity(driverName, vehicleNumber) {
+    const normalizedDriverName = normalizeDriverName(driverName);
+    const normalizedVehicleNumber = normalizeText(vehicleNumber);
+    const driverKey = normalizeDriverKey(normalizedDriverName);
+    const vehicleKey = normalizeVehicleKey(normalizedVehicleNumber);
+    const summaryKey = vehicleKey + "|" + driverKey;
+    return {
+      driverName: normalizedDriverName,
+      vehicleNumber: normalizedVehicleNumber,
+      driverKey: driverKey,
+      vehicleKey: vehicleKey,
+      summaryKey: summaryKey,
+      idSuffix: hashText(summaryKey || normalizedVehicleNumber + "|" + normalizedDriverName || "unknown")
+    };
+  }
+
+  function buildSummaryDocId(identity) {
+    return "driver_points_summary_" + identity.idSuffix;
+  }
+
+  function hashText(value) {
+    let hash = 0x811c9dc5;
+    const text = String(value == null ? "" : value);
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+  }
+
+  function normalizeMonthKey(value) {
+    const match = /^(\d{4})-(\d{1,2})$/.exec(normalizeText(value));
+    if (!match) {
+      return "";
+    }
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) {
+      return "";
+    }
+    return year + "-" + String(month).padStart(2, "0");
+  }
+
+  function normalizeDayNumber(value) {
+    const day = Number(value);
+    if (!Number.isInteger(day) || day < 1 || day > 31) {
+      return 0;
+    }
+    return day;
+  }
+
+  function buildLocalMonthKey(date) {
+    return date.getFullYear() + "-" + String(date.getMonth() + 1).padStart(2, "0");
+  }
+
+  function buildMonthKeyFromTimestamp(value) {
+    const time = getTimeValue(value);
+    if (!time) {
+      return "";
+    }
+    return buildLocalMonthKey(new Date(time));
+  }
+
+  function formatMonthLabel(value) {
+    const month = normalizeMonthKey(value);
+    if (!month) {
+      return "-";
+    }
+    const parts = month.split("-");
+    return parts[0] + "年" + String(Number(parts[1])) + "月";
+  }
+
+  function formatSignedPoints(value) {
+    const points = getNumericValue(value);
+    return (points > 0 ? "+" : "") + String(points) + "pt";
+  }
+
+  function normalizeText(value) {
+    return String(value == null ? "" : value).trim();
+  }
+
+  function normalizeDriverName(value) {
+    if (sharedSettings && typeof sharedSettings.normalizeDriverName === "function") {
+      return normalizeText(sharedSettings.normalizeDriverName(value));
+    }
+    return normalizeText(value);
+  }
+
+  function normalizeDriverKey(value) {
+    return normalizeDriverName(value)
+      .normalize("NFKC")
+      .replace(/\s+/g, "")
+      .toLowerCase();
+  }
+
+  function normalizeVehicleKey(value) {
+    return normalizeText(value)
+      .normalize("NFKC")
+      .replace(/\s+/g, "")
+      .toLowerCase();
+  }
+
+  function getNumericValue(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    const numericValue = Number(value);
+    return Number.isFinite(numericValue) ? numericValue : 0;
+  }
+
+  function getTimeValue(value) {
+    if (!value) {
+      return 0;
+    }
+    if (typeof value.toDate === "function") {
+      try {
+        return value.toDate().getTime();
+      } catch {
+        return 0;
+      }
+    }
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? 0 : value.getTime();
+    }
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue) && numericValue > 0) {
+      return numericValue;
+    }
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+  }
+
+  function hasOwn(source, key) {
+    return Boolean(source && Object.prototype.hasOwnProperty.call(source, key));
+  }
+
+  function escapeHtml(value) {
+    return String(value == null ? "" : value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+
+  function setStatus(message, isError) {
+    if (!elements.statusText) {
+      return;
+    }
+    elements.statusText.textContent = message || "";
+    elements.statusText.style.color = isError ? "#b00020" : "";
+  }
+
+  function formatError(error) {
+    if (!error) {
+      return "unknown_error";
+    }
+    if (error.code) {
+      return String(error.code);
+    }
+    if (error.message) {
+      return String(error.message);
+    }
+    return String(error);
+  }
+
+  function getServerQuerySnapshot(query) {
+    return query.get(SERVER_GET_OPTIONS);
+  }
+
+  function getServerDocumentSnapshot(docRef) {
+    return docRef.get(SERVER_GET_OPTIONS);
+  }
+})();

--- a/sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.css
+++ b/sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.css
@@ -47,6 +47,10 @@
     #fff;
 }
 
+.points-summary-readonly {
+  grid-template-columns: 1fr;
+}
+
 .summary-copy {
   display: grid;
   gap: 8px;
@@ -91,6 +95,14 @@
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(243, 247, 251, 0.96));
   box-shadow: 0 28px 60px rgba(24, 42, 64, 0.24);
+}
+
+.leaderboard-panel-inline {
+  height: min(70vh, 720px);
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .leaderboard-topbar {
@@ -214,30 +226,14 @@ body.leaderboard-open {
     border-radius: 22px;
   }
 
+  .leaderboard-panel-inline {
+    padding: 0;
+    border-radius: 0;
+  }
+
   .leaderboard-topbar {
     align-items: stretch;
     flex-direction: column;
   }
 }
 
-.field-inline-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.field-inline-action .mini-button {
-  min-width: 132px;
-}
-
-@media (max-width: 720px) {
-  .field-inline-header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .field-inline-action .mini-button {
-    width: 100%;
-  }
-}

--- a/sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.js
+++ b/sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.js
@@ -21,17 +21,8 @@
   });
 
   const elements = {
-    vehicleSelect: document.getElementById("vehicleSelect"),
-    driverSelect: document.getElementById("driverSelect"),
-    saveButton: document.getElementById("saveButton"),
-    openLeaderboardButton: document.getElementById("openLeaderboardButton"),
-    closeLeaderboardButton: document.getElementById("closeLeaderboardButton"),
-    leaderboardOverlay: document.getElementById("leaderboardOverlay"),
     leaderboardStatus: document.getElementById("leaderboardStatus"),
     leaderboardBody: document.getElementById("leaderboardBody"),
-    pointsValue: document.getElementById("pointsValue"),
-    pointsInput: document.getElementById("pointsInput"),
-    pointsMeta: document.getElementById("pointsMeta"),
     statusText: document.getElementById("statusText")
   };
 
@@ -44,47 +35,10 @@
     driverOptions: [],
     leaderboardRows: [],
     loadingPoints: false,
-    savingPoints: false,
     loadingLeaderboard: false
   };
 
-  bindEvents();
   void initialize();
-
-  function bindEvents() {
-    elements.vehicleSelect.addEventListener("change", function () {
-      void loadPointsForCurrentSelection();
-    });
-
-    elements.driverSelect.addEventListener("change", function () {
-      void loadPointsForCurrentSelection();
-    });
-
-    elements.saveButton.addEventListener("click", function () {
-      void savePoints();
-    });
-
-    elements.openLeaderboardButton.addEventListener("click", function () {
-      void openLeaderboard();
-    });
-
-    elements.closeLeaderboardButton.addEventListener("click", function () {
-      closeLeaderboard();
-    });
-
-    elements.pointsInput.addEventListener("keydown", function (event) {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        void savePoints();
-      }
-    });
-
-    document.addEventListener("keydown", function (event) {
-      if (event.key === "Escape" && !elements.leaderboardOverlay.hidden) {
-        closeLeaderboard();
-      }
-    });
-  }
 
   async function initialize() {
     setStatus("候補を読み込んでいます...");
@@ -99,12 +53,8 @@
       state.optionSourceReady = true;
 
       if (state.vehicleOptions.length && state.driverOptions.length) {
-        elements.vehicleSelect.value = "";
-        elements.driverSelect.value = "";
-        elements.pointsValue.textContent = "--";
-        elements.pointsInput.value = "";
-        elements.pointsMeta.textContent = "車番と乗務員を選択してください。";
-        setStatus("車番と乗務員を選択してください。");
+        setStatus("");
+        await loadLeaderboard();
       } else {
         setStatus("車番または乗務員の候補がまだありません。設定画面で登録してください。", true);
       }
@@ -140,8 +90,6 @@
 
     state.vehicleOptions = buildVehicleOptions(localOptions.vehicles, cloudVehicles);
     state.driverOptions = buildDriverOptions(localOptions.drivers, cloudDrivers);
-    renderOptions(elements.vehicleSelect, state.vehicleOptions, "車番を選択");
-    renderOptions(elements.driverSelect, state.driverOptions, "乗務員を選択");
   }
 
   async function initializePointsDb() {
@@ -251,77 +199,6 @@
     });
 
     return options;
-  }
-
-  function renderOptions(select, options, placeholder) {
-    select.innerHTML = "";
-
-    const placeholderOption = document.createElement("option");
-    placeholderOption.value = "";
-    placeholderOption.textContent = placeholder;
-    select.appendChild(placeholderOption);
-
-    options.forEach(function (option) {
-      const optionElement = document.createElement("option");
-      optionElement.value = option.value;
-      optionElement.textContent = option.label;
-      select.appendChild(optionElement);
-    });
-  }
-
-  async function loadPointsForCurrentSelection(forceReloadSchema) {
-    const vehicle = normalizeText(elements.vehicleSelect.value);
-    const driverOption = getSelectedDriverOption();
-
-    state.currentRecord = null;
-    elements.pointsMeta.textContent = "ポイントを検索しています...";
-    elements.pointsValue.textContent = "--";
-
-    if (!vehicle || !driverOption) {
-      elements.pointsMeta.textContent = "車番と乗務員を選択してください。";
-      elements.pointsInput.value = "";
-      setStatus("車番と乗務員を選択してください。", true);
-      syncButtons();
-      return;
-    }
-
-    if (!state.pointsDb) {
-      setStatus("ポイント用 Firebase に接続できていません。", true);
-      syncButtons();
-      return;
-    }
-
-    state.loadingPoints = true;
-    syncButtons();
-
-    try {
-      const schema = await resolveSchema(forceReloadSchema === true);
-      const record = await findPointRecord(schema, vehicle, driverOption);
-
-      state.activeSchema = schema;
-      state.currentRecord = record;
-
-      if (!record) {
-        elements.pointsValue.textContent = "0";
-        elements.pointsInput.value = "";
-        elements.pointsMeta.textContent = "該当データはまだありません。新規保存すると作成されます。";
-        setStatus("該当するポイントデータは未登録です。");
-        return;
-      }
-
-      const points = getRecordPoints(record, schema);
-      elements.pointsValue.textContent = String(points);
-      elements.pointsInput.value = "";
-      elements.pointsMeta.textContent = "";
-      setStatus("ポイントを読み込みました。");
-    } catch (error) {
-      console.warn("Failed to load points:", error);
-      elements.pointsMeta.textContent = "ポイントの読み込みに失敗しました。";
-      setStatus("ポイントの読み込みに失敗しました: " + formatError(error), true);
-    } finally {
-      state.loadingPoints = false;
-      syncButtons();
-    }
   }
 
   async function resolveSchema(forceReloadSchema) {
@@ -465,278 +342,6 @@
     };
   }
 
-  async function findPointRecord(schema, vehicle, driverOption) {
-    let matchingRecord = null;
-    const collectionRef = state.pointsDb.collection(schema.collectionName);
-    const summaryKindValue = normalizeText(pointsSettings.summaryKindValue);
-
-    if (summaryKindValue) {
-      for (const vehicleField of uniqueFieldNames((pointsSettings.vehicleFieldCandidates || []).concat(schema.vehicleField))) {
-        try {
-          const summarySnapshot = await getServerQuerySnapshot(
-            collectionRef
-              .where("kind", "==", summaryKindValue)
-              .where(vehicleField, "==", vehicle)
-              .limit(100)
-          );
-          const summaryCandidates = summarySnapshot.docs.map(function (docSnapshot) {
-            return {
-              id: docSnapshot.id,
-              ref: docSnapshot.ref,
-              data: docSnapshot.data() || {}
-            };
-          }).filter(function (record) {
-            return recordMatchesSelection(record, schema, vehicle, driverOption);
-          });
-
-          matchingRecord = pickBestPointRecord(summaryCandidates, schema);
-          if (matchingRecord) {
-            return matchingRecord;
-          }
-        } catch (error) {
-          console.warn("Summary filtered query failed:", vehicleField, error);
-        }
-      }
-
-      try {
-        const summarySnapshot = await getServerQuerySnapshot(
-          collectionRef
-            .where("kind", "==", summaryKindValue)
-            .limit(300)
-        );
-        const summaryCandidates = summarySnapshot.docs.map(function (docSnapshot) {
-          return {
-            id: docSnapshot.id,
-            ref: docSnapshot.ref,
-            data: docSnapshot.data() || {}
-          };
-        }).filter(function (record) {
-          return recordMatchesSelection(record, schema, vehicle, driverOption);
-        });
-
-        matchingRecord = pickBestPointRecord(summaryCandidates, schema);
-        if (matchingRecord) {
-          return matchingRecord;
-        }
-      } catch (error) {
-        console.warn("Summary collection scan failed:", error);
-      }
-    }
-
-    for (const vehicleField of uniqueFieldNames((pointsSettings.vehicleFieldCandidates || []).concat(schema.vehicleField))) {
-      try {
-        const filteredSnapshot = await getServerQuerySnapshot(
-          collectionRef
-            .where(vehicleField, "==", vehicle)
-            .limit(100)
-        );
-        const candidates = filteredSnapshot.docs.map(function (docSnapshot) {
-          return {
-            id: docSnapshot.id,
-            ref: docSnapshot.ref,
-            data: docSnapshot.data() || {}
-          };
-        }).filter(function (record) {
-          return recordMatchesSelection(record, schema, vehicle, driverOption);
-        });
-
-        matchingRecord = pickBestPointRecord(candidates, schema);
-        if (matchingRecord) {
-          return matchingRecord;
-        }
-      } catch (error) {
-        console.warn("Vehicle filtered query failed:", vehicleField, error);
-      }
-    }
-
-    if (!matchingRecord) {
-      const snapshot = await getServerQuerySnapshot(
-        collectionRef.limit(300)
-      );
-      const candidates = snapshot.docs
-        .map(function (docSnapshot) {
-          return {
-            id: docSnapshot.id,
-            ref: docSnapshot.ref,
-            data: docSnapshot.data() || {}
-          };
-        })
-        .filter(function (record) {
-          return recordMatchesSelection(record, schema, vehicle, driverOption);
-        });
-      matchingRecord = pickBestPointRecord(candidates, schema);
-    }
-
-    if (matchingRecord) {
-      return matchingRecord;
-    }
-
-    for (const docId of buildCandidateDocIds(schema, vehicle, driverOption)) {
-      const docSnapshot = await getServerDocumentSnapshot(
-        state.pointsDb.collection(schema.collectionName).doc(docId)
-      );
-      if (docSnapshot.exists) {
-        return {
-          id: docSnapshot.id,
-          ref: docSnapshot.ref,
-          data: docSnapshot.data() || {}
-        };
-      }
-    }
-
-    return null;
-  }
-
-  function recordMatchesSelection(record, schema, vehicle, driverOption) {
-    const vehicleKeys = collectNormalizedFieldValues(
-      record.data,
-      uniqueFieldNames([schema.vehicleField].concat(pointsSettings.vehicleFieldCandidates || [])),
-      normalizeText
-    );
-    const driverKeys = collectNormalizedFieldValues(
-      record.data,
-      uniqueFieldNames(["driverRaw", "driverDisplay", "driverAliases", schema.driverField].concat(pointsSettings.driverFieldCandidates || [])),
-      normalizeDriverKey
-    );
-    const selectedDriverKeys = [driverOption.value, driverOption.label]
-      .map(function (value) {
-        return normalizeDriverKey(value);
-      })
-      .filter(Boolean);
-
-    return vehicleKeys.includes(vehicle) && driverKeys.some(function (value) {
-      return selectedDriverKeys.includes(value);
-    });
-  }
-
-  function pickBestPointRecord(records, schema) {
-    if (!Array.isArray(records) || !records.length) {
-      return null;
-    }
-
-    const candidates = records.filter(isSummaryPointRecord);
-    if (!candidates.length) {
-      return null;
-    }
-
-    candidates.sort(function (left, right) {
-      return getRecordUpdatedAtTime(right.data, schema) - getRecordUpdatedAtTime(left.data, schema);
-    });
-
-    return candidates[0] || null;
-  }
-
-  function buildCandidateDocIds(schema, vehicle, driverOption) {
-    const docIds = [];
-    const seen = new Set();
-    const rawDriver = normalizeText(driverOption.value);
-    const displayDriver = normalizeText(driverOption.label);
-
-    (schema.docIdPatterns || []).forEach(function (pattern) {
-      [
-        pattern.replace("{vehicle}", sanitizeDocIdPart(vehicle)).replace("{driver}", sanitizeDocIdPart(rawDriver)),
-        pattern.replace("{vehicle}", sanitizeDocIdPart(vehicle)).replace("{driver}", sanitizeDocIdPart(displayDriver))
-      ].forEach(function (docId) {
-        if (!docId || seen.has(docId)) {
-          return;
-        }
-        seen.add(docId);
-        docIds.push(docId);
-      });
-    });
-
-    return docIds;
-  }
-
-  async function savePoints() {
-    const vehicle = normalizeText(elements.vehicleSelect.value);
-    const driverOption = getSelectedDriverOption();
-    const rawDeltaPoints = normalizeText(elements.pointsInput.value);
-    const deltaPoints = Number(rawDeltaPoints);
-
-    if (!vehicle || !driverOption) {
-      setStatus("保存する前に車番と乗務員を選択してください。", true);
-      return;
-    }
-
-    if (!rawDeltaPoints || !Number.isFinite(deltaPoints)) {
-      setStatus("加点または減点するポイント数を入力してください。", true);
-      return;
-    }
-
-    if (!state.pointsDb) {
-      setStatus("ポイント用 Firebase に接続できていません。", true);
-      return;
-    }
-
-    state.savingPoints = true;
-    syncButtons();
-
-    try {
-      const schema = await resolveSchema(false);
-      const existingRecord = await findPointRecord(schema, vehicle, driverOption);
-      const collectionRef = state.pointsDb.collection(schema.collectionName);
-      const currentPoints = existingRecord ? getRecordPoints(existingRecord, schema) : 0;
-      const nextPoints = currentPoints + deltaPoints;
-      const payload = {};
-      const pointsFieldName = resolvePointsFieldName(existingRecord ? existingRecord.data : null, schema);
-
-      payload[pointsFieldName] = nextPoints;
-      payload[schema.updatedAtField] = window.firebase.firestore.FieldValue.serverTimestamp();
-
-      if (existingRecord) {
-        await collectionRef.doc(existingRecord.id).set(payload, { merge: true });
-      } else {
-        payload.kind = normalizeText(pointsSettings.summaryKindValue) || "driver_points_summary";
-        payload.vehicleNumber = vehicle;
-        payload.vehicleKey = vehicle;
-        payload.driverName = driverOption.label;
-        payload.driverKey = normalizeDriverKey(driverOption.label);
-        payload[schema.vehicleField] = vehicle;
-        payload[schema.driverField] = schema.driverField === "driverKey"
-          ? normalizeDriverKey(driverOption.label)
-          : driverOption.label;
-        payload.driverRaw = driverOption.value;
-        payload.createdAt = window.firebase.firestore.FieldValue.serverTimestamp();
-
-        const newDocId = buildNewDocId(schema, vehicle, driverOption);
-        await collectionRef.doc(newDocId).set(payload, { merge: true });
-      }
-
-      await loadPointsForCurrentSelection();
-      setStatus("ポイントを更新しました: " + currentPoints + (deltaPoints >= 0 ? " + " : " - ") + Math.abs(deltaPoints) + " = " + nextPoints);
-    } catch (error) {
-      console.warn("Failed to save points:", error);
-      setStatus("ポイントの保存に失敗しました: " + formatError(error), true);
-    } finally {
-      state.savingPoints = false;
-      syncButtons();
-    }
-  }
-
-  function buildNewDocId(schema, vehicle, driverOption) {
-    const summaryPrefix = "driver_points_summary_";
-    if (window.crypto && typeof window.crypto.randomUUID === "function") {
-      return summaryPrefix + window.crypto.randomUUID().replace(/-/g, "").slice(0, 8);
-    }
-    return summaryPrefix + Date.now().toString(16);
-  }
-
-  async function openLeaderboard() {
-    elements.leaderboardOverlay.hidden = false;
-    elements.leaderboardOverlay.setAttribute("aria-hidden", "false");
-    document.body.classList.add("leaderboard-open");
-    elements.leaderboardStatus.textContent = "一覧を読み込んでいます...";
-    elements.leaderboardBody.innerHTML = '<tr><td colspan="3">読み込み中...</td></tr>';
-    await loadLeaderboard();
-  }
-
-  function closeLeaderboard() {
-    elements.leaderboardOverlay.hidden = true;
-    elements.leaderboardOverlay.setAttribute("aria-hidden", "true");
-    document.body.classList.remove("leaderboard-open");
-  }
-
   async function loadLeaderboard() {
     if (!state.pointsDb) {
       elements.leaderboardStatus.textContent = "Firebase に接続できていません。";
@@ -745,6 +350,8 @@
     }
 
     state.loadingLeaderboard = true;
+    elements.leaderboardStatus.textContent = "一覧を読み込んでいます...";
+    elements.leaderboardBody.innerHTML = '<tr><td colspan="3">読み込み中...</td></tr>';
     syncButtons();
 
     try {
@@ -842,6 +449,9 @@
       }
 
       const points = getRecordPoints(record, schema);
+      if (points === 0) {
+        return;
+      }
       const existing = totalsByDriver.get(driverKey);
       if (existing) {
         existing.points += points;
@@ -871,18 +481,6 @@
       });
     });
 
-    driverMetaByKey.forEach(function (meta, driverKey) {
-      if (!totalsByDriver.has(driverKey)) {
-        totalsByDriver.set(driverKey, {
-          key: driverKey,
-          name: meta.name,
-          order: meta.order,
-          points: 0,
-          breakdowns: []
-        });
-      }
-    });
-
     return Array.from(totalsByDriver.values()).sort(function (left, right) {
       if (right.points !== left.points) {
         return right.points - left.points;
@@ -905,7 +503,7 @@
 
     elements.leaderboardStatus.textContent = rows.length + "名のポイントを表示しています。";
     elements.leaderboardBody.innerHTML = rows.map(function (row, index) {
-      const breakdownMarkup = (Array.isArray(row.breakdowns) && row.breakdowns.length > 1
+      const breakdownMarkup = (Array.isArray(row.breakdowns) && row.breakdowns.length
         ? row.breakdowns.slice().sort(function (left, right) {
             if (right.points !== left.points) {
               return right.points - left.points;
@@ -974,17 +572,6 @@
       || "名称未設定";
   }
 
-  function getSelectedDriverOption() {
-    const selectedValue = normalizeText(elements.driverSelect.value);
-    if (!selectedValue) {
-      return null;
-    }
-
-    return state.driverOptions.find(function (option) {
-      return option.value === selectedValue;
-    }) || null;
-  }
-
   function getStringArray(source) {
     if (!source || !Array.isArray(source.values)) {
       return [];
@@ -1010,10 +597,6 @@
       .normalize("NFKC")
       .replace(/\s+/g, "")
       .toLowerCase();
-  }
-
-  function sanitizeDocIdPart(value) {
-    return normalizeText(value).replace(/[\/\\?#\[\]]/g, "-");
   }
 
   function escapeHtml(value) {
@@ -1177,9 +760,6 @@
   }
 
   function syncButtons() {
-    const hasSelection = Boolean(normalizeText(elements.vehicleSelect.value) && getSelectedDriverOption());
-    elements.saveButton.disabled = !hasSelection || state.loadingPoints || state.savingPoints || !state.pointsDb;
-    elements.openLeaderboardButton.disabled = state.loadingLeaderboard || !state.pointsDb;
   }
 
   function setStatus(message, isError) {

--- a/sinyuubuturyuu-pc/driver-points-kanri/index.html
+++ b/sinyuubuturyuu-pc/driver-points-kanri/index.html
@@ -12,8 +12,8 @@
       window.__SINYUUBUTURYUU_PC_VERSION__ = version;
     })();
   </script>
-  <title>ポイント付与管理 | シンユウ物流パソコン用</title>
-  <meta name="description" content="車番と乗務員ごとのポイントを確認して保存する管理画面">
+  <title>社員ポイント一覧 | シンユウ物流パソコン用</title>
+  <meta name="description" content="社員ごとのポイント一覧を確認する管理画面">
   <link rel="icon" href="../icons/icon-sinyuubuturyuu-pc.png" type="image/png">
   <link rel="apple-touch-icon" href="../icons/icon-sinyuubuturyuu-pc.png">
   <link rel="manifest" href="../manifest.webmanifest?v=20260330a">
@@ -26,75 +26,33 @@
     <section class="shell-card points-card">
       <div class="settings-topbar">
         <a class="back-link" href="../index.html">トップへ戻る</a>
-        <h1>ポイント付与管理</h1>
+        <h1>社員ポイント一覧</h1>
       </div>
 
-      <div class="points-grid">
-        <label class="field">
-          <span>車番</span>
-          <select id="vehicleSelect">
-            <option value="">読み込み中...</option>
-          </select>
-        </label>
-
-        <label class="field">
-          <span>乗務員</span>
-          <select id="driverSelect">
-            <option value="">読み込み中...</option>
-          </select>
-        </label>
-      </div>
-
-      <section class="points-summary" aria-labelledby="pointsSummaryHeading">
-        <div class="summary-copy">
-          <p id="pointsSummaryHeading" class="summary-label">現在のポイント</p>
-          <p id="pointsValue" class="points-value">--</p>
-          <p id="pointsMeta" class="status-text">まだポイントを読み込んでいません。</p>
-        </div>
-
-        <label class="field field-inline-action">
-          <span class="field-inline-header">
-            <span>加減算ポイント</span>
-            <button id="saveButton" class="mini-button primary" type="button">確定</button>
-          </span>
-          <input id="pointsInput" type="number" inputmode="numeric" step="1" placeholder="+10 または -5">
-        </label>
-      </section>
-
-      <div class="button-row">
-        <button id="openLeaderboardButton" class="mini-button secondary" type="button">社員ポイント一覧を見る</button>
-      </div>
       <p id="statusText" class="status-text" aria-live="polite"></p>
+
+      <section id="leaderboardPanel" class="leaderboard-panel leaderboard-panel-inline">
+        <p id="leaderboardStatus" class="status-text" aria-live="polite"></p>
+
+        <div class="leaderboard-table-wrap">
+          <table class="leaderboard-table">
+            <thead>
+              <tr>
+                <th>順位</th>
+                <th>社員名</th>
+                <th>ポイント</th>
+              </tr>
+            </thead>
+            <tbody id="leaderboardBody">
+              <tr>
+                <td colspan="3">読み込み中...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
     </section>
   </main>
-
-  <section id="leaderboardOverlay" class="leaderboard-overlay" hidden aria-hidden="true">
-    <div class="leaderboard-panel">
-      <div class="leaderboard-topbar">
-        <h2>社員ポイント一覧</h2>
-        <button id="closeLeaderboardButton" class="mini-button secondary" type="button">閉じる</button>
-      </div>
-
-      <p id="leaderboardStatus" class="status-text" aria-live="polite"></p>
-
-      <div class="leaderboard-table-wrap">
-        <table class="leaderboard-table">
-          <thead>
-            <tr>
-              <th>順位</th>
-              <th>社員名</th>
-              <th>ポイント</th>
-            </tr>
-          </thead>
-          <tbody id="leaderboardBody">
-            <tr>
-              <td colspan="3">読み込み中...</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
 
   <script>
     (function () {

--- a/sinyuubuturyuu-pc/index.html
+++ b/sinyuubuturyuu-pc/index.html
@@ -13,7 +13,7 @@
     })();
   </script>
   <title>シンユウ物流パソコン用</title>
-  <meta name="description" content="月次タイヤ点検表と月次日常点検表、ポイント管理画面のランチャーです。">
+  <meta name="description" content="月次タイヤ点検表と月次日常点検表、社員ポイント一覧、各種管理画面のランチャーです。">
   <link rel="icon" href="./icons/icon-sinyuubuturyuu-pc.png" type="image/png">
   <link rel="apple-touch-icon" href="./icons/icon-sinyuubuturyuu-pc.png">
   <link rel="manifest" href="./manifest.webmanifest?v=20260404b">
@@ -64,7 +64,8 @@
         <nav class="home-actions" aria-label="アプリ選択">
           <a id="tireInspectionButton" class="action-button primary" href="./getujitiretenkenhyou-pc/index.html">月次タイヤ点検表</a>
           <a id="dailyInspectionButton" class="action-button primary" href="./getujinitijyoutenkenhyou-pc/index.html">月次日常点検表</a>
-          <a id="driverPointsButton" class="action-button primary" href="./driver-points-kanri/index.html">ポイント管理</a>
+          <a id="driverPointsButton" class="action-button primary" href="./driver-points-kanri/index.html">社員ポイント一覧</a>
+          <a id="dataAdjustmentButton" class="action-button secondary" href="./driver-points-kanri/data-adjustment.html">データ調整</a>
           <a id="settingsButton" class="action-button secondary" href="./settings.html">設定</a>
         </nav>
       </section>

--- a/sinyuubuturyuu-pc/launcher.js
+++ b/sinyuubuturyuu-pc/launcher.js
@@ -13,6 +13,7 @@ const elements = {
   tireInspectionButton: document.getElementById("tireInspectionButton"),
   dailyInspectionButton: document.getElementById("dailyInspectionButton"),
   driverPointsButton: document.getElementById("driverPointsButton"),
+  dataAdjustmentButton: document.getElementById("dataAdjustmentButton"),
   settingsButton: document.getElementById("settingsButton")
 };
 
@@ -222,6 +223,7 @@ function setVersionedLinks() {
   setVersionedHref(elements.tireInspectionButton, "./getujitiretenkenhyou-pc/index.html");
   setVersionedHref(elements.dailyInspectionButton, "./getujinitijyoutenkenhyou-pc/index.html");
   setVersionedHref(elements.driverPointsButton, "./driver-points-kanri/index.html");
+  setVersionedHref(elements.dataAdjustmentButton, "./driver-points-kanri/data-adjustment.html");
   setVersionedHref(elements.settingsButton, "./settings.html");
 }
 
@@ -240,6 +242,7 @@ function bindLauncherWindowLinks() {
   window.launcherWindow.bindInspectionLaunch(elements.tireInspectionButton);
   window.launcherWindow.bindInspectionLaunch(elements.dailyInspectionButton);
   window.launcherWindow.bindLauncherSizedLaunch(elements.driverPointsButton);
+  window.launcherWindow.bindLauncherSizedLaunch(elements.dataAdjustmentButton);
   window.launcherWindow.bindLauncherSizedLaunch(elements.settingsButton);
 }
 

--- a/sinyuubuturyuu/getujitiretenkenhyou/app.js
+++ b/sinyuubuturyuu/getujitiretenkenhyou/app.js
@@ -994,31 +994,14 @@
       }
 
       function autoSelectSingleCurrentMonthIfNeeded() {
-        if (!hasBasicSelectionTarget()) return false;
-        if (availableMonthKeys.length !== 1) return false;
-        const onlyMonth = normalizeMonthKey(availableMonthKeys[0]);
-        const currentMonth = currentMonthKey();
-        if (!onlyMonth || onlyMonth !== currentMonth) return false;
-
-        const nextInspectionDate = normalizeInspectionDateForMonth(today(), currentMonth);
-        const hasSameTarget = normalizeMonthKey(current.targetMonth) === currentMonth;
-        const hasSameDate = String(current.inspectionDate || "").trim() === nextInspectionDate;
-        const isConfirmed = current.inspectionDateConfirmed === true;
-        if (hasSameTarget && hasSameDate && isConfirmed) {
-          return false;
-        }
-
-        current.targetMonth = currentMonth;
-        current.inspectionDate = nextInspectionDate;
-        current.inspectionDateConfirmed = true;
-        return true;
+        return false;
       }
 
       function shouldHideSingleCurrentMonthStatus() {
         if (availableMonthKeys.length !== 1) return false;
         const onlyMonth = normalizeMonthKey(availableMonthKeys[0]);
         if (!onlyMonth || onlyMonth !== currentMonthKey()) return false;
-        return normalizeMonthKey(current.targetMonth) === onlyMonth;
+        return current.inspectionDateConfirmed === true && normalizeMonthKey(current.targetMonth) === onlyMonth;
       }
 
       function renderMonthSelection() {
@@ -1039,12 +1022,13 @@
         }
 
         availableMonthKeys.forEach((monthKey) => {
+          const active = confirmed && selectedMonth === monthKey;
           const button = document.createElement("button");
           button.type = "button";
-          button.className = `btn${selectedMonth === monthKey ? " primary" : ""}`;
+          button.className = `btn${active ? " primary" : ""}`;
           button.textContent = formatMonthLabel(monthKey);
           button.dataset.monthKey = monthKey;
-          button.setAttribute("aria-pressed", selectedMonth === monthKey ? "true" : "false");
+          button.setAttribute("aria-pressed", active ? "true" : "false");
           el.targetMonthButtons.appendChild(button);
         });
         if (monthSelectionError) {
@@ -1063,7 +1047,7 @@
           el.monthSelectionStatus.textContent = `${formatMonthLabel(current.targetMonth)} / 点検日: ${formatDateLabel(current.inspectionDate)}`;
           return;
         }
-        if (selectedMonth) {
+        if (selectedMonth && confirmed) {
           el.monthSelectionStatus.textContent = `${formatMonthLabel(selectedMonth)} / 点検日: ${formatDateLabel(current.inspectionDate)}`;
           return;
         }
@@ -2379,7 +2363,7 @@
           ev.preventDefault();
           ev.stopImmediatePropagation();
           const selectedMonth = normalizeMonthKey(current.targetMonth);
-          if (!selectedMonth) {
+          if (!selectedMonth || current.inspectionDateConfirmed !== true) {
             showToast("対象月を選択してから点検を開始してください");
             return;
           }


### PR DESCRIPTION
## 概要

管理者が Firebase を直接編集しなくても、誤送信・不要データ・残ったポイントイベントを安全に確認/削除できる「管理者用データ調整」ページを追加しました。

あわせて、ポイント管理画面を「社員ポイント一覧」として整理し、車番/乗務員を選択しなくても社員ごとのポイント一覧を確認できるようにしました。

## 主な変更

- PC版トップ画面に「データ調整」ページへの導線を追加
- 管理者用データ調整ページを新規追加
- 乗務員、車番、対象月を選択して対象データを確認できるように変更
- 対象月のポイントイベントを一覧表示し、削除対象を選択できるように変更
- 削除前に関連データ、削除予定、ポイント変化、整合性を表示
- 削除実行時にポイントサマリーをイベント履歴から再計算
- 削除ログを `admin_data_adjustment_logs` に保存
- 元の点検データがすでに削除されている場合でも、選択したポイントイベントを削除できるように変更
- ポイント付与管理画面を「社員ポイント一覧」に変更
- 手動の加点/減点機能を削除
- 月次タイヤ点検表アプリで、対象月ボタンが初期状態では選択色にならないように変更

## 安全対策

- 削除前に必ず確認画面を表示
- 削除対象が1件に特定できない場合は削除不可
- 複数候補がある場合は自動判断しない
- 削除後はポイントサマリーを再計算
- 削除内容とポイント変化をログに保存
- 元データが無い場合は警告を表示し、ポイントイベントのみ削除

## 確認したこと

- JS構文チェック済み

```text
node --check sinyuubuturyuu-pc/driver-points-kanri/data-adjustment.js
node --check sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.js
node --check sinyuubuturyuu/getujitiretenkenhyou/app.js
