### PR TITLE
[codex] Improve notice link preview

### DIFF
--- a/pages/notice/index.html
+++ b/pages/notice/index.html
@@ -4,6 +4,23 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>点検アプリ導入のお知らせ</title>
+<meta name="description" content="シンユウ物流アプリの導入案内です。インストール方法、ログイン方法、点検表の使い方を確認できます。">
+<meta name="theme-color" content="#007bff">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="シンユウ物流">
+<meta property="og:title" content="点検アプリ導入のお知らせ">
+<meta property="og:description" content="インストール方法、ログイン方法、点検表の使い方をまとめています。">
+<meta property="og:url" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/pages/notice/">
+<meta property="og:image" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/icon-512.png">
+<meta property="og:image:width" content="512">
+<meta property="og:image:height" content="512">
+<meta property="og:image:alt" content="シンユウ物流アプリアイコン">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="点検アプリ導入のお知らせ">
+<meta name="twitter:description" content="インストール方法、ログイン方法、点検表の使い方をまとめています。">
+<meta name="twitter:image" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/icon-512.png">
+<link rel="icon" type="image/png" href="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/icon-192.png">
+<link rel="apple-touch-icon" href="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/apple-touch-icon.png">
 <style>
 body {font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;margin:0;padding:16px;line-height:1.6;background:#f7f7f7;color:#333;}
 .container {max-width:600px;margin:auto;background:#fff;padding:20px;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.05);}

--- a/pages/notice/index.html
+++ b/pages/notice/index.html
@@ -11,14 +11,12 @@
 <meta property="og:title" content="点検アプリ導入のお知らせ">
 <meta property="og:description" content="インストール方法、ログイン方法、点検表の使い方をまとめています。">
 <meta property="og:url" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/pages/notice/">
-<meta property="og:image" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/icon-512.png">
-<meta property="og:image:width" content="512">
-<meta property="og:image:height" content="512">
-<meta property="og:image:alt" content="シンユウ物流アプリアイコン">
+<meta property="og:image" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/sinyuubuturyuu-icon.png">
+<meta property="og:image:alt" content="シンユウ物流ロゴ">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="点検アプリ導入のお知らせ">
 <meta name="twitter:description" content="インストール方法、ログイン方法、点検表の使い方をまとめています。">
-<meta name="twitter:image" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/icon-512.png">
+<meta name="twitter:image" content="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/sinyuubuturyuu-icon.png">
 <link rel="icon" type="image/png" href="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/icon-192.png">
 <link rel="apple-touch-icon" href="https://sinyuubuturyuu.github.io/sinyuubuturyuu-apps3/sinyuubuturyuu/apple-touch-icon.png">
 <style>


### PR DESCRIPTION
## What changed
- Added social preview metadata for the notice page.
- Switched the preview image to the company logo.

## Why
- Improve how the notice link appears when shared in LINE.

## Impact
- Changes only the metadata in pages/notice/index.html.
- No change to the notice page body or app behavior.

## Notes
- LINE may cache previews for a while before showing the updated image and text.