### PR TITLE
[codex] Remove mobile app login and settings copy

### DIFF
--- a/sinyuubuturyuu/driver-points/driver-points.js
+++ b/sinyuubuturyuu/driver-points/driver-points.js
@@ -749,13 +749,10 @@
     const field = document.createElement("label");
     field.className = "field";
 
-    const label = document.createElement("span");
-    label.textContent = "機能切替";
-    field.appendChild(label);
-
     const toggle = document.createElement("select");
     toggle.id = "driverPointsFeatureToggle";
     toggle.className = "field-select";
+    toggle.setAttribute("aria-label", "ポイント付与機能切替");
     toggle.innerHTML = [
       '<option value="off">OFF</option>',
       '<option value="on">ON</option>'
@@ -807,11 +804,6 @@
     const summary = head && head.querySelector("p");
     if (summary) {
       summary.remove();
-    }
-
-    const label = section.querySelector(".field > span");
-    if (label) {
-      label.textContent = "ポイント付与";
     }
 
     let helpButton = section.querySelector("#driverPointsHelpButton");

--- a/sinyuubuturyuu/index.html
+++ b/sinyuubuturyuu/index.html
@@ -25,7 +25,6 @@
       </section>
 
       <section id="loginPanel" class="auth-panel" aria-label="ログイン" hidden>
-        <p class="auth-copy">メールアドレスとパスワードでログインしてください。</p>
         <form id="loginForm" class="auth-form">
           <label class="field">
             <span>メールアドレス</span>
@@ -94,7 +93,6 @@
         <section class="settings-section">
           <div class="section-head">
             <h3>車両番号</h3>
-            <p>追加後は必ず保存してください。</p>
           </div>
           <div class="field">
             <span>表示する車両番号</span>
@@ -105,7 +103,6 @@
         <section class="settings-section">
           <div class="section-head">
             <h3>乗務員名</h3>
-            <p>追加後は必ず保存してください。</p>
           </div>
           <div class="field">
             <span>表示する乗務員名</span>

--- a/sinyuubuturyuu/launcher.js
+++ b/sinyuubuturyuu/launcher.js
@@ -342,7 +342,7 @@ async function handleLoginSubmit() {
   }
 
   state.auth.busy = true;
-  setAuthStatus("ログインしています。", false);
+  setAuthStatus("", false);
   renderAll();
 
   try {
@@ -363,7 +363,7 @@ async function handleLogout() {
   }
 
   state.auth.busy = true;
-  setAuthStatus("ログアウトしています。", false);
+  setAuthStatus("", false);
   renderAll();
 
   try {


### PR DESCRIPTION
## What changed
- Removed the login guidance text from the mobile app login screen.
- Hid the temporary login/logout status messages during auth transitions.
- Removed the settings helper copy about saving after changes.
- Removed the visible "�|�C���g�t�^" label while keeping the feature toggle working.

## Why
- Simplify the mobile app UI by removing unnecessary explanatory text.

## Impact
- Changes only the mobile app text shown in the launcher/settings UI.
- Point feature behavior remains unchanged.

## Notes
- An unrelated local change to `sinyuubuturyuu-apps-notice.html` was intentionally left out of this PR.
