### PR TITLE
PC版アプリ初回起動時のバージョン競合を修正

### DIFF
--- a/sinyuubuturyuu-pc/manifest.webmanifest
+++ b/sinyuubuturyuu-pc/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "シンユウ物流パソコン用",
   "short_name": "シンユウ物流PC",
   "description": "月次タイヤ点検表と月次日常点検表のランチャー",
-  "start_url": "./index.html?v=20260409a",
+  "start_url": "./index.html?v=20260504a",
   "scope": "./",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/sinyuubuturyuu-pc/sw.js
+++ b/sinyuubuturyuu-pc/sw.js
@@ -1,4 +1,4 @@
-const APP_VERSION = "20260419a";
+const APP_VERSION = "20260504a";
 const VERSION_PARAM = "v";
 
 self.addEventListener("install", function (event) {


### PR DESCRIPTION
## 概要

PC版アプリの初回起動時に、Service Worker とアプリ側バージョン同期の指定が食い違い、起動直後のボタン操作が効かないように見える問題を修正します。

## 変更内容

- `sinyuubuturyuu-pc/sw.js` の `APP_VERSION` を `20260504a` に更新
- `sinyuubuturyuu-pc/manifest.webmanifest` の `start_url` を `./index.html?v=20260504a` に更新

## 背景

`version-sync.js` は最新版を `20260504a` として扱っていますが、Service Worker は `20260419a`、manifest の `start_url` は `20260409a` のままでした。

そのため初回起動時に、ページが最新版へ移動した後、Service Worker が古い `v=` に戻し、さらに最新版へ戻るような遷移競合が発生する可能性がありました。

## 確認

- `node --check sinyuubuturyuu-pc\sw.js`
- `manifest.webmanifest` のJSON parse確認
- `version-sync.js` / `sw.js` / `manifest.webmanifest` のバージョン一致確認

## 影響範囲

ボタン処理、認証処理、各アプリ画面のロジックには触れていません。初回起動時のバージョン指定不一致のみを修正しています。