### PR TITLE
[codex] Add daily safety quiz draft

### DIFF
--- a/sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.css
+++ b/sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.css
@@ -1,0 +1,165 @@
+.quiz-admin-card {
+  width: min(1180px, calc(100vw - 32px));
+}
+
+.quiz-admin-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.quiz-admin-section {
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--card);
+}
+
+.quiz-admin-section h2,
+.quiz-admin-section h3 {
+  margin: 0 0 12px;
+}
+
+.quiz-admin-help {
+  margin: 0 0 14px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.quiz-form {
+  display: grid;
+  gap: 14px;
+}
+
+.quiz-form .field {
+  margin-bottom: 0;
+}
+
+.choice-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.choice-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.choice-row strong {
+  text-align: center;
+}
+
+.month-checks {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.month-check,
+.inline-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--bg-accent);
+  font-weight: 700;
+}
+
+.quiz-toolbar {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.quiz-list {
+  display: grid;
+  gap: 10px;
+}
+
+.quiz-item {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #ffffff;
+}
+
+.quiz-item-head {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.quiz-item-title {
+  margin: 0;
+  font-weight: 800;
+  line-height: 1.5;
+}
+
+.quiz-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.quiz-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--bg-accent);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.quiz-badge.enabled {
+  background: rgba(27, 122, 75, 0.12);
+  color: #1b7a4b;
+}
+
+.quiz-badge.disabled {
+  background: rgba(178, 60, 42, 0.12);
+  color: #b23c2a;
+}
+
+.quiz-item-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.quiz-empty {
+  padding: 18px;
+  border: 1px dashed var(--line);
+  border-radius: 14px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.settings-mini-grid {
+  display: grid;
+  gap: 10px;
+}
+
+@media (max-width: 900px) {
+  .quiz-admin-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .month-checks {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.html
+++ b/sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="../version-sync.js"></script>
+  <script>
+    (function () {
+      const versionSync = window.SinyuubuturyuuPcVersion || null;
+      const version = versionSync ? versionSync.ensureLatestVersion("20260627b") : "20260627b";
+      if (!version) return;
+      window.__SINYUUBUTURYUU_PC_VERSION__ = version;
+    })();
+  </script>
+  <title>今日の安全ワンポイント管理 | シンユウ物流パソコン用</title>
+  <meta name="description" content="点検後に表示する今日の安全ワンポイントクイズを管理する画面">
+  <link rel="icon" href="../icons/icon-sinyuubuturyuu-pc.png" type="image/png">
+  <link rel="apple-touch-icon" href="../icons/icon-sinyuubuturyuu-pc.png">
+  <link rel="manifest" href="../manifest.webmanifest?v=20260404b">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="../shell.css?v=20260404b">
+  <link rel="stylesheet" href="./driver-points-kanri.css?v=20260404a">
+  <link rel="stylesheet" href="./daily-safety-quiz.css?v=20260627a">
+</head>
+<body class="shell-body">
+  <main class="shell-page">
+    <section class="shell-card quiz-admin-card">
+      <div class="settings-topbar">
+        <a class="back-link" href="../index.html">トップへ戻る</a>
+        <h1>今日の安全ワンポイント管理</h1>
+      </div>
+
+      <p id="statusText" class="status-text" aria-live="polite"></p>
+
+      <div class="quiz-admin-grid">
+        <section class="quiz-admin-section" aria-labelledby="formHeading">
+          <h2 id="formHeading">問題の追加・編集</h2>
+          <p class="quiz-admin-help">正解時は解説を表示せず、不正解時だけ解説を表示します。出題月は複数選べます。</p>
+
+          <form id="quizForm" class="quiz-form">
+            <label class="field">
+              <span>カテゴリ</span>
+              <select id="categoryInput" class="field-select" required>
+                <option value="交通安全">交通安全</option>
+                <option value="車両整備">車両整備</option>
+                <option value="運行管理">運行管理</option>
+              </select>
+            </label>
+
+            <label class="field">
+              <span>問題文</span>
+              <textarea id="questionInput" rows="3" required></textarea>
+            </label>
+
+            <div class="field">
+              <span>選択肢と正解</span>
+              <div class="choice-grid">
+                <label class="choice-row">
+                  <strong>1</strong>
+                  <input id="choice0Input" type="text" required>
+                  <input type="radio" name="correctChoice" value="0" checked aria-label="1を正解にする">
+                </label>
+                <label class="choice-row">
+                  <strong>2</strong>
+                  <input id="choice1Input" type="text" required>
+                  <input type="radio" name="correctChoice" value="1" aria-label="2を正解にする">
+                </label>
+                <label class="choice-row">
+                  <strong>3</strong>
+                  <input id="choice2Input" type="text" required>
+                  <input type="radio" name="correctChoice" value="2" aria-label="3を正解にする">
+                </label>
+                <label class="choice-row">
+                  <strong>4</strong>
+                  <input id="choice3Input" type="text" required>
+                  <input type="radio" name="correctChoice" value="3" aria-label="4を正解にする">
+                </label>
+              </div>
+            </div>
+
+            <label class="field">
+              <span>不正解時の解説</span>
+              <textarea id="explanationInput" rows="4" required></textarea>
+            </label>
+
+            <div class="field">
+              <span>出題月</span>
+              <label class="inline-check">
+                <input id="allMonthsInput" type="checkbox" checked>
+                <span>いつでも</span>
+              </label>
+              <div id="monthChecks" class="month-checks" aria-label="出題月"></div>
+            </div>
+
+            <label class="inline-check">
+              <input id="enabledInput" type="checkbox" checked>
+              <span>有効にする</span>
+            </label>
+
+            <div class="button-row">
+              <button id="saveButton" class="mini-button primary" type="submit">保存</button>
+              <button id="cancelEditButton" class="mini-button" type="button" hidden>編集をやめる</button>
+            </div>
+          </form>
+        </section>
+
+        <section class="quiz-admin-section" aria-labelledby="listHeading">
+          <div class="quiz-toolbar">
+            <div>
+              <h2 id="listHeading">問題一覧</h2>
+              <p id="quizCountText" class="status-text"></p>
+            </div>
+            <button id="sampleButton" class="mini-button" type="button">サンプル追加</button>
+            <button id="reloadButton" class="mini-button" type="button">再読込</button>
+          </div>
+          <div id="quizList" class="quiz-list"></div>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <script src="../launcher-window.js?v=20260330a"></script>
+  <script>
+    (function () {
+      const topBackLink = document.querySelector(".back-link");
+      if (window.launcherWindow) {
+        window.launcherWindow.maximizeCurrentWindowIfRequested();
+        window.launcherWindow.bindReturnToLauncher(topBackLink);
+      }
+    })();
+  </script>
+  <script src="../shared-settings.js?v=20260330a"></script>
+  <script src="../getujitiretenkenhyou-pc/firebase/firebase-config.js?v=20260404b"></script>
+  <script src="./firebase-config.js?v=20260404b"></script>
+  <script src="../auth/firebase-auth.js?v=20260404b"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
+  <script>
+    (function () {
+      const version = window.__SINYUUBUTURYUU_PC_VERSION__
+        || (window.SinyuubuturyuuPcVersion ? window.SinyuubuturyuuPcVersion.getVersion("20260627b") : "20260627b");
+      const launcherUrl = new URL("../index.html", window.location.href);
+      launcherUrl.searchParams.set("returnTo", window.location.href);
+
+      const authApi = window.DevFirebaseAuth;
+      if (!authApi || typeof authApi.requireUser !== "function") {
+        console.warn("Auth bootstrap was not available.");
+        window.location.replace(launcherUrl.toString());
+        return;
+      }
+
+      authApi.requireUser({ redirectTo: launcherUrl.toString(), waitMs: 5000 }).then(function (user) {
+        if (!user) return;
+        const script = document.createElement("script");
+        script.src = "./daily-safety-quiz.js?v=" + version;
+        document.body.appendChild(script);
+      }).catch(function (error) {
+        console.warn("Auth bootstrap failed:", error);
+        window.location.replace(launcherUrl.toString());
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.js
+++ b/sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.js
@@ -1,0 +1,473 @@
+(function () {
+  "use strict";
+
+  const quizConfig = window.DRIVER_POINTS_FIREBASE_CONFIG || window.APP_FIREBASE_CONFIG || null;
+  const QUIZ_COLLECTION = "daily-safety-quizzes";
+  const SERVER_GET_OPTIONS = Object.freeze({ source: "server" });
+  const MONTHS = Array.from({ length: 12 }, function (_, index) { return index + 1; });
+  const SAMPLE_QUIZZES = Object.freeze([
+    {
+      category: "交通安全",
+      question: "雨の日の運転で特に意識することは？",
+      choices: ["速度を控えめにして車間距離を長めに取る", "いつもより車間距離を短くする", "急ブレーキを多く使う", "ライトを消して走る"],
+      correctIndex: 0,
+      explanation: "雨の日は止まる距離が長くなります。早めの減速と長めの車間距離を意識しましょう。"
+    },
+    {
+      category: "車両整備",
+      question: "出発前にタイヤまわりで見るべきことは？",
+      choices: ["空気圧不足や損傷がないか", "車内の音楽設定", "配送先の売上", "休憩所の混雑"],
+      correctIndex: 0,
+      explanation: "タイヤの異常は事故につながります。出発前に空気圧不足や損傷を確認しましょう。"
+    },
+    {
+      category: "運行管理",
+      question: "眠気を感じたときに優先すべき行動は？",
+      choices: ["安全な場所で休憩する", "窓を開ければ走り続ける", "音楽を大きくして我慢する", "予定を優先して急ぐ"],
+      correctIndex: 0,
+      explanation: "眠気を感じたら無理をせず、安全な場所で休憩することが大切です。"
+    }
+  ]);
+
+  const elements = {
+    statusText: document.getElementById("statusText"),
+    quizForm: document.getElementById("quizForm"),
+    categoryInput: document.getElementById("categoryInput"),
+    questionInput: document.getElementById("questionInput"),
+    choiceInputs: [
+      document.getElementById("choice0Input"),
+      document.getElementById("choice1Input"),
+      document.getElementById("choice2Input"),
+      document.getElementById("choice3Input")
+    ],
+    explanationInput: document.getElementById("explanationInput"),
+    allMonthsInput: document.getElementById("allMonthsInput"),
+    monthChecks: document.getElementById("monthChecks"),
+    enabledInput: document.getElementById("enabledInput"),
+    saveButton: document.getElementById("saveButton"),
+    cancelEditButton: document.getElementById("cancelEditButton"),
+    sampleButton: document.getElementById("sampleButton"),
+    reloadButton: document.getElementById("reloadButton"),
+    quizCountText: document.getElementById("quizCountText"),
+    quizList: document.getElementById("quizList")
+  };
+
+  const state = {
+    db: null,
+    user: null,
+    quizzes: [],
+    editingId: "",
+    busy: false
+  };
+
+  void initialize();
+
+  async function initialize() {
+    renderMonthChecks();
+    bindEvents();
+    setStatus("読み込んでいます...");
+    try {
+      await initializeDb();
+      await loadQuizzes();
+      setStatus("");
+    } catch (error) {
+      console.warn("Failed to initialize daily safety quiz admin:", error);
+      setStatus("初期化に失敗しました: " + formatError(error), true);
+    }
+  }
+
+  function bindEvents() {
+    elements.quizForm.addEventListener("submit", function (event) {
+      event.preventDefault();
+      void saveQuiz();
+    });
+    elements.cancelEditButton.addEventListener("click", resetForm);
+    elements.sampleButton.addEventListener("click", function () {
+      void addSampleQuizzes();
+    });
+    elements.reloadButton.addEventListener("click", function () {
+      void loadQuizzes();
+    });
+    elements.allMonthsInput.addEventListener("change", syncMonthInputs);
+  }
+
+  function renderMonthChecks() {
+    elements.monthChecks.innerHTML = MONTHS.map(function (month) {
+      return [
+        '<label class="month-check">',
+        '<input type="checkbox" data-month-value="' + String(month) + '">',
+        '<span>' + String(month) + "月</span>",
+        "</label>"
+      ].join("");
+    }).join("");
+  }
+
+  function syncMonthInputs() {
+    const disabled = elements.allMonthsInput.checked;
+    elements.monthChecks.querySelectorAll("input[data-month-value]").forEach(function (input) {
+      input.disabled = disabled;
+      if (disabled) {
+        input.checked = false;
+      }
+    });
+  }
+
+  async function initializeDb() {
+    if (!quizConfig || !firebase || !firebase.apps) {
+      throw new Error("Firebase config is missing.");
+    }
+
+    const appName = "daily-safety-quiz-admin";
+    const app = firebase.apps.some(function (currentApp) { return currentApp.name === appName; })
+      ? firebase.app(appName)
+      : firebase.initializeApp(quizConfig, appName);
+    const auth = app.auth();
+    const authApi = window.DevFirebaseAuth;
+
+    if (authApi && typeof authApi.ensureCompatUser === "function") {
+      state.user = await authApi.ensureCompatUser(auth, { waitMs: 5000 });
+    } else if (authApi && typeof authApi.getCurrentUser === "function") {
+      state.user = await authApi.getCurrentUser({ waitMs: 5000 });
+    } else {
+      state.user = auth.currentUser || null;
+    }
+
+    if (!state.user) {
+      throw new Error("Please sign in.");
+    }
+
+    state.db = app.firestore();
+  }
+
+  async function loadQuizzes() {
+    if (!state.db) return;
+    setBusy(true);
+    setStatus("問題を読み込んでいます...");
+    try {
+      const snapshot = await state.db.collection(QUIZ_COLLECTION).get(SERVER_GET_OPTIONS);
+      state.quizzes = snapshot.docs.map(function (docSnapshot) {
+        return {
+          id: docSnapshot.id,
+          data: normalizeQuiz(docSnapshot.data() || {})
+        };
+      }).sort(compareQuiz);
+      renderQuizList();
+      setStatus("");
+    } catch (error) {
+      console.warn("Failed to load quizzes:", error);
+      setStatus("問題の読み込みに失敗しました: " + formatError(error), true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function normalizeQuiz(data) {
+    return {
+      category: normalizeText(data.category) || "交通安全",
+      question: normalizeText(data.question),
+      choices: Array.isArray(data.choices) ? data.choices.map(normalizeText).slice(0, 4) : [],
+      correctIndex: normalizeCorrectIndex(data.correctIndex),
+      explanation: normalizeText(data.explanation),
+      enabled: data.enabled !== false,
+      monthKeys: normalizeMonthKeys(data.monthKeys),
+      quizNumber: Number(data.quizNumber || 0),
+      randomKey: Number(data.randomKey || 0)
+    };
+  }
+
+  function compareQuiz(left, right) {
+    if (left.data.enabled !== right.data.enabled) {
+      return left.data.enabled ? -1 : 1;
+    }
+    if (left.data.quizNumber !== right.data.quizNumber) {
+      return left.data.quizNumber - right.data.quizNumber;
+    }
+    return left.data.question.localeCompare(right.data.question, "ja", { numeric: true, sensitivity: "base" });
+  }
+
+  function renderQuizList() {
+    const quizzes = state.quizzes || [];
+    elements.quizCountText.textContent = quizzes.length ? String(quizzes.length) + "問" : "";
+    if (!quizzes.length) {
+      elements.quizList.innerHTML = '<div class="quiz-empty">まだ問題がありません。</div>';
+      return;
+    }
+
+    elements.quizList.innerHTML = quizzes.map(function (entry) {
+      const quiz = entry.data;
+      return [
+        '<article class="quiz-item" data-quiz-id="' + escapeHtml(entry.id) + '">',
+        '<div class="quiz-item-head">',
+        '<p class="quiz-item-title">' + escapeHtml(quiz.question) + "</p>",
+        '<span class="quiz-badge ' + (quiz.enabled ? "enabled" : "disabled") + '">' + (quiz.enabled ? "有効" : "無効") + "</span>",
+        "</div>",
+        '<div class="quiz-badges">',
+        '<span class="quiz-badge">' + escapeHtml(quiz.category) + "</span>",
+        '<span class="quiz-badge">' + escapeHtml(formatMonthKeys(quiz.monthKeys)) + "</span>",
+        '<span class="quiz-badge">正解 ' + String(quiz.correctIndex + 1) + "</span>",
+        "</div>",
+        '<div class="quiz-item-actions">',
+        '<button class="mini-button" type="button" data-action="edit">編集</button>',
+        '<button class="mini-button" type="button" data-action="toggle">' + (quiz.enabled ? "無効にする" : "有効にする") + "</button>",
+        '<button class="mini-button danger" type="button" data-action="delete">削除</button>',
+        "</div>",
+        "</article>"
+      ].join("");
+    }).join("");
+
+    elements.quizList.querySelectorAll("[data-action]").forEach(function (button) {
+      button.addEventListener("click", function (event) {
+        const item = event.target.closest("[data-quiz-id]");
+        const quizId = item ? item.dataset.quizId : "";
+        const action = event.target.dataset.action;
+        const entry = state.quizzes.find(function (current) { return current.id === quizId; });
+        if (!entry) return;
+        if (action === "edit") {
+          startEdit(entry);
+        } else if (action === "toggle") {
+          void toggleQuiz(entry);
+        } else if (action === "delete") {
+          void deleteQuiz(entry);
+        }
+      });
+    });
+  }
+
+  function startEdit(entry) {
+    const quiz = entry.data;
+    state.editingId = entry.id;
+    elements.categoryInput.value = quiz.category;
+    elements.questionInput.value = quiz.question;
+    elements.choiceInputs.forEach(function (input, index) {
+      input.value = quiz.choices[index] || "";
+    });
+    const correctInput = elements.quizForm.querySelector('input[name="correctChoice"][value="' + String(quiz.correctIndex) + '"]');
+    if (correctInput) correctInput.checked = true;
+    elements.explanationInput.value = quiz.explanation;
+    elements.enabledInput.checked = quiz.enabled;
+    elements.allMonthsInput.checked = quiz.monthKeys.includes("all");
+    elements.monthChecks.querySelectorAll("input[data-month-value]").forEach(function (input) {
+      input.checked = quiz.monthKeys.includes(input.dataset.monthValue);
+    });
+    syncMonthInputs();
+    elements.cancelEditButton.hidden = false;
+    elements.saveButton.textContent = "更新";
+    elements.questionInput.focus();
+  }
+
+  function resetForm() {
+    state.editingId = "";
+    elements.quizForm.reset();
+    elements.categoryInput.value = "交通安全";
+    elements.enabledInput.checked = true;
+    elements.allMonthsInput.checked = true;
+    syncMonthInputs();
+    elements.cancelEditButton.hidden = true;
+    elements.saveButton.textContent = "保存";
+  }
+
+  async function addSampleQuizzes() {
+    if (!state.db || state.busy) return;
+    if (!window.confirm("サンプル問題を3問追加しますか？")) return;
+    setBusy(true);
+    setStatus("サンプル問題を追加しています...");
+    try {
+      const batch = state.db.batch();
+      const now = firebase.firestore.FieldValue.serverTimestamp();
+      SAMPLE_QUIZZES.forEach(function (quiz, index) {
+        const ref = state.db.collection(QUIZ_COLLECTION).doc();
+        batch.set(ref, {
+          category: quiz.category,
+          question: quiz.question,
+          choices: quiz.choices.slice(),
+          correctIndex: quiz.correctIndex,
+          explanation: quiz.explanation,
+          enabled: true,
+          monthKeys: ["all"],
+          quizNumber: Date.now() + index,
+          randomKey: Math.random(),
+          createdAt: now,
+          updatedAt: now,
+          updatedBy: state.user && state.user.email ? state.user.email : ""
+        });
+      });
+      await batch.commit();
+      setStatus("サンプル問題を追加しました。");
+      await loadQuizzes();
+    } catch (error) {
+      console.warn("Failed to add sample quizzes:", error);
+      setStatus("サンプル問題の追加に失敗しました: " + formatError(error), true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveQuiz() {
+    if (!state.db || state.busy) return;
+    const payload = buildPayload();
+    if (!payload) return;
+
+    setBusy(true);
+    try {
+      if (state.editingId) {
+        await state.db.collection(QUIZ_COLLECTION).doc(state.editingId).set({
+          ...payload,
+          updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+          updatedBy: state.user && state.user.email ? state.user.email : ""
+        }, { merge: true });
+        setStatus("問題を更新しました。");
+      } else {
+        const docRef = state.db.collection(QUIZ_COLLECTION).doc();
+        await docRef.set({
+          ...payload,
+          quizNumber: Date.now(),
+          randomKey: Math.random(),
+          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+          updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+          createdBy: state.user && state.user.email ? state.user.email : "",
+          updatedBy: state.user && state.user.email ? state.user.email : ""
+        });
+        setStatus("問題を追加しました。");
+      }
+      resetForm();
+      await loadQuizzes();
+    } catch (error) {
+      console.warn("Failed to save quiz:", error);
+      setStatus("保存に失敗しました: " + formatError(error), true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function buildPayload() {
+    const choices = elements.choiceInputs.map(function (input) { return normalizeText(input.value); });
+    const correctInput = elements.quizForm.querySelector('input[name="correctChoice"]:checked');
+    const correctIndex = correctInput ? Number(correctInput.value) : 0;
+    const monthKeys = getSelectedMonthKeys();
+    const payload = {
+      category: normalizeText(elements.categoryInput.value) || "交通安全",
+      question: normalizeText(elements.questionInput.value),
+      choices,
+      correctIndex,
+      explanation: normalizeText(elements.explanationInput.value),
+      enabled: elements.enabledInput.checked,
+      monthKeys
+    };
+
+    if (!payload.question) {
+      setStatus("問題文を入力してください。", true);
+      return null;
+    }
+    if (choices.some(function (choice) { return !choice; })) {
+      setStatus("選択肢を4つ入力してください。", true);
+      return null;
+    }
+    if (!payload.explanation) {
+      setStatus("不正解時の解説を入力してください。", true);
+      return null;
+    }
+    if (!monthKeys.length) {
+      setStatus("出題月を選ぶか、いつでもを選んでください。", true);
+      return null;
+    }
+    return payload;
+  }
+
+  function getSelectedMonthKeys() {
+    if (elements.allMonthsInput.checked) {
+      return ["all"];
+    }
+    return Array.from(elements.monthChecks.querySelectorAll("input[data-month-value]:checked"))
+      .map(function (input) { return input.dataset.monthValue; });
+  }
+
+  async function toggleQuiz(entry) {
+    if (!state.db || state.busy) return;
+    setBusy(true);
+    try {
+      await state.db.collection(QUIZ_COLLECTION).doc(entry.id).set({
+        enabled: !entry.data.enabled,
+        updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+        updatedBy: state.user && state.user.email ? state.user.email : ""
+      }, { merge: true });
+      setStatus(entry.data.enabled ? "問題を無効にしました。" : "問題を有効にしました。");
+      await loadQuizzes();
+    } catch (error) {
+      console.warn("Failed to toggle quiz:", error);
+      setStatus("切り替えに失敗しました: " + formatError(error), true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function deleteQuiz(entry) {
+    if (!state.db || state.busy) return;
+    const confirmed = window.confirm("この問題を削除します。元に戻せません。よろしいですか？");
+    if (!confirmed) return;
+    setBusy(true);
+    try {
+      await state.db.collection(QUIZ_COLLECTION).doc(entry.id).delete();
+      if (state.editingId === entry.id) {
+        resetForm();
+      }
+      setStatus("問題を削除しました。");
+      await loadQuizzes();
+    } catch (error) {
+      console.warn("Failed to delete quiz:", error);
+      setStatus("削除に失敗しました: " + formatError(error), true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function normalizeCorrectIndex(value) {
+    const index = Number(value);
+    return Number.isInteger(index) && index >= 0 && index <= 3 ? index : 0;
+  }
+
+  function normalizeMonthKeys(value) {
+    const keys = Array.isArray(value) ? value.map(normalizeText).filter(Boolean) : ["all"];
+    const valid = keys.filter(function (key) {
+      return key === "all" || (MONTHS.map(String).includes(key));
+    });
+    return valid.length ? Array.from(new Set(valid)) : ["all"];
+  }
+
+  function formatMonthKeys(monthKeys) {
+    if (!Array.isArray(monthKeys) || monthKeys.includes("all")) {
+      return "いつでも";
+    }
+    return monthKeys.map(function (key) { return key + "月"; }).join(" / ");
+  }
+
+  function normalizeText(value) {
+    return String(value ?? "").trim();
+  }
+
+  function setBusy(busy) {
+    state.busy = Boolean(busy);
+    elements.saveButton.disabled = state.busy;
+    elements.reloadButton.disabled = state.busy;
+  }
+
+  function setStatus(message, isError) {
+    elements.statusText.textContent = message || "";
+    elements.statusText.classList.toggle("is-error", Boolean(isError));
+  }
+
+  function formatError(error) {
+    return error && error.message ? error.message : String(error || "");
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "").replace(/[&<>"']/g, function (char) {
+      return {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;"
+      }[char];
+    });
+  }
+})();

--- a/sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.js
+++ b/sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.js
@@ -345,13 +345,13 @@
   async function loadLeaderboard() {
     if (!state.pointsDb) {
       elements.leaderboardStatus.textContent = "Firebase に接続できていません。";
-      elements.leaderboardBody.innerHTML = '<tr><td colspan="3">読み込みに失敗しました。</td></tr>';
+      elements.leaderboardBody.innerHTML = '<tr><td colspan="5">読み込みに失敗しました。</td></tr>';
       return;
     }
 
     state.loadingLeaderboard = true;
     elements.leaderboardStatus.textContent = "一覧を読み込んでいます...";
-    elements.leaderboardBody.innerHTML = '<tr><td colspan="3">読み込み中...</td></tr>';
+    elements.leaderboardBody.innerHTML = '<tr><td colspan="5">読み込み中...</td></tr>';
     syncButtons();
 
     try {
@@ -387,7 +387,7 @@
     } catch (error) {
       console.warn("Failed to load leaderboard:", error);
       elements.leaderboardStatus.textContent = "一覧の読み込みに失敗しました: " + formatError(error);
-      elements.leaderboardBody.innerHTML = '<tr><td colspan="3">一覧の読み込みに失敗しました。</td></tr>';
+      elements.leaderboardBody.innerHTML = '<tr><td colspan="5">一覧の読み込みに失敗しました。</td></tr>';
     } finally {
       state.loadingLeaderboard = false;
       syncButtons();
@@ -449,16 +449,22 @@
       }
 
       const points = getRecordPoints(record, schema);
+      const quizPoints = getRecordQuizPoints(record);
+      const inspectionPoints = Math.max(0, points - quizPoints);
       if (points === 0) {
         return;
       }
       const existing = totalsByDriver.get(driverKey);
       if (existing) {
         existing.points += points;
+        existing.inspectionPoints += inspectionPoints;
+        existing.quizPoints += quizPoints;
         existing.breakdowns.push({
           vehicleKey: resolveRecordVehicleKey(record.data),
           vehicleLabel: resolveRecordVehicleLabel(record.data),
-          points: points
+          points: points,
+          inspectionPoints: inspectionPoints,
+          quizPoints: quizPoints
         });
         return;
       }
@@ -473,10 +479,14 @@
         name: meta.name,
         order: meta.order,
         points: points,
+        inspectionPoints: inspectionPoints,
+        quizPoints: quizPoints,
         breakdowns: [{
           vehicleKey: resolveRecordVehicleKey(record.data),
           vehicleLabel: resolveRecordVehicleLabel(record.data),
-          points: points
+          points: points,
+          inspectionPoints: inspectionPoints,
+          quizPoints: quizPoints
         }]
       });
     });
@@ -497,7 +507,7 @@
 
     if (!rows.length) {
       elements.leaderboardStatus.textContent = "表示できる社員データがありません。";
-      elements.leaderboardBody.innerHTML = '<tr><td colspan="3">表示できる社員データがありません。</td></tr>';
+      elements.leaderboardBody.innerHTML = '<tr><td colspan="5">表示できる社員データがありません。</td></tr>';
       return;
     }
 
@@ -531,6 +541,8 @@
           + '<span class="leaderboard-name-text">' + escapeHtml(row.name) + "</span>"
           + (breakdownMarkup ? '<span class="leaderboard-breakdown-list">' + breakdownMarkup + "</span>" : "")
           + "</div></td>",
+        '<td class="leaderboard-points">' + String(row.inspectionPoints || 0) + "</td>",
+        '<td class="leaderboard-points">' + String(row.quizPoints || 0) + "</td>",
         '<td class="leaderboard-points">' + String(row.points) + "</td>",
         "</tr>"
       ].join("");
@@ -640,6 +652,11 @@
   function getRecordPoints(record, schema) {
     const fieldName = resolvePointsFieldName(record && record.data ? record.data : null, schema);
     return getNumericValue(record && record.data ? record.data[fieldName] : undefined);
+  }
+
+  function getRecordQuizPoints(record) {
+    const data = record && record.data ? record.data : {};
+    return getNumericValue(data.dailySafetyQuizPoints ?? data.dailySafetyQuizTotalPoints);
   }
 
   function uniqueFieldNames(values) {

--- a/sinyuubuturyuu-pc/driver-points-kanri/index.html
+++ b/sinyuubuturyuu-pc/driver-points-kanri/index.html
@@ -40,12 +40,14 @@
               <tr>
                 <th>順位</th>
                 <th>社員名</th>
-                <th>ポイント</th>
+                <th>点検</th>
+                <th>クイズ</th>
+                <th>合計</th>
               </tr>
             </thead>
             <tbody id="leaderboardBody">
               <tr>
-                <td colspan="3">読み込み中...</td>
+                <td colspan="5">読み込み中...</td>
               </tr>
             </tbody>
           </table>

--- a/sinyuubuturyuu-pc/index.html
+++ b/sinyuubuturyuu-pc/index.html
@@ -66,6 +66,7 @@
           <a id="dailyInspectionButton" class="action-button primary" href="./getujinitijyoutenkenhyou-pc/index.html">月次日常点検表</a>
           <a id="driverPointsButton" class="action-button primary" href="./driver-points-kanri/index.html">社員ポイント一覧</a>
           <a id="dataAdjustmentButton" class="action-button secondary" href="./driver-points-kanri/data-adjustment.html">データ調整</a>
+          <a id="dailySafetyQuizButton" class="action-button secondary" href="./driver-points-kanri/daily-safety-quiz.html">今日の安全ワンポイント管理</a>
           <a id="settingsButton" class="action-button secondary" href="./settings.html">設定</a>
         </nav>
       </section>

--- a/sinyuubuturyuu-pc/launcher.js
+++ b/sinyuubuturyuu-pc/launcher.js
@@ -14,6 +14,7 @@ const elements = {
   dailyInspectionButton: document.getElementById("dailyInspectionButton"),
   driverPointsButton: document.getElementById("driverPointsButton"),
   dataAdjustmentButton: document.getElementById("dataAdjustmentButton"),
+  dailySafetyQuizButton: document.getElementById("dailySafetyQuizButton"),
   settingsButton: document.getElementById("settingsButton")
 };
 
@@ -224,6 +225,7 @@ function setVersionedLinks() {
   setVersionedHref(elements.dailyInspectionButton, "./getujinitijyoutenkenhyou-pc/index.html");
   setVersionedHref(elements.driverPointsButton, "./driver-points-kanri/index.html");
   setVersionedHref(elements.dataAdjustmentButton, "./driver-points-kanri/data-adjustment.html");
+  setVersionedHref(elements.dailySafetyQuizButton, "./driver-points-kanri/daily-safety-quiz.html");
   setVersionedHref(elements.settingsButton, "./settings.html");
 }
 
@@ -243,6 +245,7 @@ function bindLauncherWindowLinks() {
   window.launcherWindow.bindInspectionLaunch(elements.dailyInspectionButton);
   window.launcherWindow.bindLauncherSizedLaunch(elements.driverPointsButton);
   window.launcherWindow.bindLauncherSizedLaunch(elements.dataAdjustmentButton);
+  window.launcherWindow.bindLauncherSizedLaunch(elements.dailySafetyQuizButton);
   window.launcherWindow.bindLauncherSizedLaunch(elements.settingsButton);
 }
 

--- a/sinyuubuturyuu/daily-safety-quiz/daily-safety-quiz.js
+++ b/sinyuubuturyuu/daily-safety-quiz/daily-safety-quiz.js
@@ -1,0 +1,693 @@
+(function () {
+  "use strict";
+
+  const FIREBASE_CONFIG = Object.freeze(getRuntimeFirebaseConfig(window.APP_FIREBASE_CONFIG || window.APP_FIREBASE_DIRECTORY_CONFIG || {}));
+  const COLLECTIONS = Object.freeze({
+    quizzes: "daily-safety-quizzes",
+    answers: "daily-safety-quiz-answers",
+    progress: "daily-safety-quiz-progress",
+    points: "driver-points"
+  });
+  const QUIZ_READ_LIMIT = 30;
+  const DISPLAY_SETTINGS_STORAGE_KEY = "sinyuubuturyuu.dailySafetyQuizDisplaySettings.v1";
+  const DEFAULT_SETTINGS = Object.freeze({
+    quizEnabled: true,
+    completionImageEnabled: true
+  });
+
+  const runtimeState = {
+    promise: null,
+  };
+
+  function normalizeText(value) {
+    return String(value ?? "").trim();
+  }
+
+  function normalizeDriverName(value) {
+    const text = normalizeText(value)
+      .replace(/\s*[（(][^）)]*[）)]\s*/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return text === "\u672a\u9078\u629e" ? "" : text;
+  }
+
+  function normalizeVehicleNumber(value) {
+    const text = normalizeText(value)
+      .replace(/\s+/g, " ")
+      .trim();
+    return text === "\u672a\u9078\u629e" ? "" : text;
+  }
+  function buildDriverKey(driverName) {
+    return normalizeDriverName(driverName)
+      .normalize("NFKC")
+      .replace(/\s+/g, "")
+      .toLowerCase();
+  }
+
+  function buildVehicleKey(vehicleNumber) {
+    return normalizeVehicleNumber(vehicleNumber)
+      .normalize("NFKC")
+      .replace(/\s+/g, "")
+      .toLowerCase();
+  }
+
+  function hashText(value) {
+    let hash = 0x811c9dc5;
+    const text = String(value ?? "");
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+  }
+
+  function buildIdentity(driverName, vehicleNumber) {
+    const normalizedDriverName = normalizeDriverName(driverName);
+    const normalizedVehicleNumber = normalizeVehicleNumber(vehicleNumber);
+    const driverKey = buildDriverKey(normalizedDriverName);
+    const vehicleKey = buildVehicleKey(normalizedVehicleNumber);
+    const summaryKey = `${vehicleKey}|${driverKey}`;
+    const driverProgressKey = driverKey || normalizedDriverName || 'unknown';
+    return {
+      driverName: normalizedDriverName,
+      vehicleNumber: normalizedVehicleNumber,
+      driverKey,
+      vehicleKey,
+      summaryKey,
+      idSuffix: hashText(summaryKey || `${normalizedVehicleNumber}|${normalizedDriverName}` || "unknown"),
+      progressIdSuffix: hashText(driverProgressKey)
+    };
+  }
+
+  function buildSummaryDocId(identity) {
+    return `driver_points_summary_${identity.idSuffix}`;
+  }
+
+  function buildEventDocId(eventId) {
+    return `driver_points_event_${hashText(eventId)}`;
+  }
+
+  function buildLocalDateKey(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  function buildMonthKey(date = new Date()) {
+    return String(date.getMonth() + 1);
+  }
+
+  function buildAnsweredQuizKey(dateKey, quizId) {
+    return hashText(`${dateKey}|${quizId}`);
+  }
+
+  function buildQuizProgressKey(quizId) {
+    return hashText(quizId);
+  }
+
+  function isLocalDevelopmentHost() {
+    const host = window.location.hostname;
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+      || /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host);
+  }
+
+  function shouldUseFirebaseEmulator() {
+    return window.APP_USE_FIREBASE_EMULATOR === true && isLocalDevelopmentHost();
+  }
+
+  function getRuntimeFirebaseConfig(config) {
+    return shouldUseFirebaseEmulator()
+      ? { ...(config || {}), ...(window.APP_FIREBASE_EMULATOR_CONFIG || {}) }
+      : (config || {});
+  }
+
+  function getFirebaseEmulatorRuntime() {
+    return {
+      authUrl: "http://127.0.0.1:9099",
+      firestoreHost: "127.0.0.1",
+      firestorePort: 8080,
+      ...(window.APP_FIREBASE_EMULATOR || {})
+    };
+  }
+
+  function connectAuthEmulatorIfNeeded(authModule, auth) {
+    if (!shouldUseFirebaseEmulator() || !authModule || typeof authModule.connectAuthEmulator !== "function" || auth.__sinyuubuturyuuQuizEmulatorConnected) {
+      return;
+    }
+    authModule.connectAuthEmulator(auth, getFirebaseEmulatorRuntime().authUrl, { disableWarnings: true });
+    auth.__sinyuubuturyuuQuizEmulatorConnected = true;
+  }
+
+  function connectFirestoreEmulatorIfNeeded(firestoreModule, db) {
+    if (!shouldUseFirebaseEmulator() || !firestoreModule || typeof firestoreModule.connectFirestoreEmulator !== "function" || db.__sinyuubuturyuuQuizEmulatorConnected) {
+      return;
+    }
+    const runtime = getFirebaseEmulatorRuntime();
+    firestoreModule.connectFirestoreEmulator(db, runtime.firestoreHost, runtime.firestorePort);
+    db.__sinyuubuturyuuQuizEmulatorConnected = true;
+  }
+
+  function hasFirebaseConfig() {
+    return ["apiKey", "authDomain", "projectId", "appId"].every((key) => {
+      const value = FIREBASE_CONFIG[key];
+      return typeof value === "string" && value.trim();
+    });
+  }
+
+  async function waitForSignedInUser(authApi, authModule, auth) {
+    if (authApi && typeof authApi.getCurrentUser === "function") {
+      return authApi.getCurrentUser({ waitMs: 5000 });
+    }
+    if (auth.currentUser) {
+      return auth.currentUser;
+    }
+    if (typeof auth.authStateReady === "function") {
+      await auth.authStateReady();
+      return auth.currentUser || null;
+    }
+    return new Promise((resolve) => {
+      let settled = false;
+      let unsubscribe = () => {};
+      const finish = (user) => {
+        if (settled) return;
+        settled = true;
+        unsubscribe();
+        resolve(user || null);
+      };
+      unsubscribe = authModule.onAuthStateChanged(auth, (user) => finish(user), () => finish(null));
+      window.setTimeout(() => finish(auth.currentUser || null), 5000);
+    });
+  }
+
+  async function ensureRuntime() {
+    if (!hasFirebaseConfig()) {
+      throw new Error("Firebase config is missing for daily safety quiz.");
+    }
+    if (runtimeState.promise) {
+      return runtimeState.promise;
+    }
+
+    runtimeState.promise = (async () => {
+      const [{ getApp, getApps, initializeApp }, authModule, firestoreModule] = await Promise.all([
+        import("https://www.gstatic.com/firebasejs/12.10.0/firebase-app.js"),
+        import("https://www.gstatic.com/firebasejs/12.10.0/firebase-auth.js"),
+        import("https://www.gstatic.com/firebasejs/12.10.0/firebase-firestore.js")
+      ]);
+
+      const authApi = window.DevFirebaseAuth;
+      let app = null;
+      let auth = null;
+      if (authApi && typeof authApi.ensureRuntime === "function") {
+        const sharedRuntime = await authApi.ensureRuntime();
+        app = sharedRuntime && sharedRuntime.app ? sharedRuntime.app : null;
+        auth = sharedRuntime && sharedRuntime.auth ? sharedRuntime.auth : null;
+      }
+      if (!app) {
+        app = typeof getApps === "function" && getApps().length ? getApp() : initializeApp(FIREBASE_CONFIG);
+      }
+      if (!auth) {
+        auth = authModule.getAuth(app);
+      }
+      connectAuthEmulatorIfNeeded(authModule, auth);
+
+      const user = await waitForSignedInUser(authApi, authModule, auth);
+      if (!user) {
+        throw new Error("ログインしてください。");
+      }
+
+      const db = firestoreModule.getFirestore(app);
+      connectFirestoreEmulatorIfNeeded(firestoreModule, db);
+      return { db, user, firestoreModule };
+    })().catch((error) => {
+      runtimeState.promise = null;
+      throw error;
+    });
+    return runtimeState.promise;
+  }
+
+  function readLocalDisplaySettings() {
+    try {
+      const raw = window.localStorage.getItem(DISPLAY_SETTINGS_STORAGE_KEY);
+      if (!raw) return null;
+      const data = JSON.parse(raw);
+      return {
+        quizEnabled: data.quizEnabled !== false,
+        completionImageEnabled: data.completionImageEnabled !== false
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async function loadSettings() {
+    return readLocalDisplaySettings() || { ...DEFAULT_SETTINGS };
+  }
+
+  async function shouldShowCompletionImage() {
+    const settings = await loadSettings();
+    return settings.completionImageEnabled !== false;
+  }
+
+  async function shouldShowQuiz() {
+    const settings = await loadSettings();
+    return settings.quizEnabled !== false;
+  }
+
+  function ensureStyle() {
+    if (document.getElementById("dailySafetyQuizStyle")) {
+      return;
+    }
+    const style = document.createElement("style");
+    style.id = "dailySafetyQuizStyle";
+    style.textContent = [
+      ".daily-safety-quiz-dialog{width:min(520px,calc(100vw - 24px));max-width:100%;border:0;border-radius:20px;padding:0;background:#fff;color:#17202a;box-shadow:0 24px 80px rgba(15,23,42,.28)}",
+      ".daily-safety-quiz-dialog::backdrop{background:rgba(8,15,28,.48);backdrop-filter:blur(3px)}",
+      ".daily-safety-quiz-panel{display:grid;gap:16px;padding:22px}",
+      ".daily-safety-quiz-title{margin:0;font-size:1.2rem;font-weight:800;line-height:1.35}",
+      ".daily-safety-quiz-meta{display:inline-flex;width:max-content;max-width:100%;border-radius:999px;background:#eef5ff;color:#1769d2;padding:5px 10px;font-size:.82rem;font-weight:800}",
+      ".daily-safety-quiz-question{margin:0;font-size:1.05rem;font-weight:800;line-height:1.6}",
+      ".daily-safety-quiz-choices{display:grid;gap:10px}",
+      ".daily-safety-quiz-choice{display:grid;grid-template-columns:28px 1fr;align-items:center;gap:10px;width:100%;min-height:54px;border:1px solid #cfd8e4;border-radius:14px;background:#f8fafc;color:#17202a;padding:12px 14px;text-align:left;font:inherit;font-weight:700;cursor:pointer}",
+      ".daily-safety-quiz-choice-mark{width:22px;height:22px;border:2px solid #8aa0b8;border-radius:50%;background:#fff;display:inline-block;position:relative}",
+      ".daily-safety-quiz-choice.is-selected{border-color:#1769d2;background:#edf5ff}",
+      ".daily-safety-quiz-choice.is-selected .daily-safety-quiz-choice-mark{border-color:#1769d2}",
+      ".daily-safety-quiz-choice.is-selected .daily-safety-quiz-choice-mark::after{content:'';position:absolute;inset:4px;border-radius:50%;background:#1769d2}",
+      ".daily-safety-quiz-actions{display:grid;gap:10px}",
+      ".daily-safety-quiz-button{min-height:52px;border:0;border-radius:14px;background:#1769d2;color:#fff;font:inherit;font-weight:800;cursor:pointer}",
+      ".daily-safety-quiz-button:disabled{opacity:.55;cursor:not-allowed}",
+      ".daily-safety-quiz-secondary{background:#e8eef6;color:#17202a}",
+      ".daily-safety-quiz-result{display:grid;gap:12px}",
+      ".daily-safety-quiz-result-heading{margin:0;font-size:1.15rem;font-weight:900;line-height:1.45}",
+      ".daily-safety-quiz-explanation{margin:0;line-height:1.7;color:#334155;white-space:pre-line}",
+      ".daily-safety-quiz-correct-answer{padding:12px;border-radius:12px;background:#f3f8ef;color:#245b2a;font-weight:800;line-height:1.6}",
+      "@media (max-width:480px){.daily-safety-quiz-panel{padding:18px}.daily-safety-quiz-title{font-size:1.08rem}}"
+    ].join("\n");
+    document.head.appendChild(style);
+  }
+
+  function closeDialog(dialog) {
+    if (!dialog) return;
+    if (dialog.open && typeof dialog.close === "function") {
+      dialog.close();
+    }
+    dialog.remove();
+  }
+
+  function renderDoneDialog(message) {
+    ensureStyle();
+    return new Promise((resolve) => {
+      const dialog = document.createElement("dialog");
+      dialog.className = "daily-safety-quiz-dialog";
+      dialog.innerHTML = [
+        '<div class="daily-safety-quiz-panel">',
+        '<h2 class="daily-safety-quiz-title">今日の安全ワンポイント</h2>',
+        '<p class="daily-safety-quiz-explanation">' + escapeHtml(message) + "</p>",
+        '<div class="daily-safety-quiz-actions">',
+        '<button class="daily-safety-quiz-button" type="button">完了</button>',
+        "</div>",
+        "</div>"
+      ].join("");
+      dialog.querySelector("button").addEventListener("click", () => {
+        closeDialog(dialog);
+        resolve();
+      });
+      document.body.appendChild(dialog);
+      showDialog(dialog);
+    });
+  }
+
+  function showDialog(dialog) {
+    if (typeof dialog.showModal === "function") {
+      dialog.showModal();
+    } else {
+      dialog.setAttribute("open", "");
+    }
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "").replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;"
+    })[char]);
+  }
+
+  function normalizeQuiz(snapshotDoc) {
+    const data = snapshotDoc.data() || {};
+    const choices = Array.isArray(data.choices) ? data.choices.map(normalizeText).filter(Boolean).slice(0, 4) : [];
+    return {
+      id: snapshotDoc.id,
+      category: normalizeText(data.category),
+      question: normalizeText(data.question),
+      choices,
+      correctIndex: Number(data.correctIndex || 0),
+      explanation: normalizeText(data.explanation),
+      enabled: data.enabled !== false
+    };
+  }
+
+  function isUsableQuiz(quiz) {
+    return quiz
+      && quiz.enabled
+      && quiz.question
+      && quiz.choices.length === 4
+      && Number.isInteger(quiz.correctIndex)
+      && quiz.correctIndex >= 0
+      && quiz.correctIndex < 4;
+  }
+
+  function shuffle(items, seedText) {
+    const next = items.slice();
+    let seed = parseInt(hashText(seedText), 16) || 1;
+    for (let index = next.length - 1; index > 0; index -= 1) {
+      seed = Math.imul(seed ^ (seed >>> 15), 2246822507) >>> 0;
+      const target = seed % (index + 1);
+      const temp = next[index];
+      next[index] = next[target];
+      next[target] = temp;
+    }
+    return next;
+  }
+
+  async function fetchQuizPool(runtime, monthKey) {
+    const { collection, getDocs, limit, query, where } = runtime.firestoreModule;
+    const collectionRef = collection(runtime.db, COLLECTIONS.quizzes);
+    const queries = [
+      query(collectionRef, where("monthKeys", "array-contains", monthKey), limit(QUIZ_READ_LIMIT)),
+      query(collectionRef, where("monthKeys", "array-contains", "all"), limit(QUIZ_READ_LIMIT)),
+      query(collectionRef, limit(QUIZ_READ_LIMIT))
+    ];
+    const snapshots = await Promise.all(queries.map((currentQuery) => getDocs(currentQuery)));
+    const seen = new Set();
+    const quizzes = [];
+    snapshots.forEach((snapshot) => {
+      snapshot.docs.forEach((snapshotDoc) => {
+        if (seen.has(snapshotDoc.id)) return;
+        seen.add(snapshotDoc.id);
+        const quiz = normalizeQuiz(snapshotDoc);
+        if (isUsableQuiz(quiz)) {
+          quizzes.push(quiz);
+        }
+      });
+    });
+    return quizzes;
+  }
+
+  async function selectQuiz(runtime, identity, progress, dateKey) {
+    const monthKey = buildMonthKey();
+    const quizzes = await fetchQuizPool(runtime, monthKey);
+    const correctQuizIds = progress && progress.correctQuizIds && typeof progress.correctQuizIds === "object"
+      ? progress.correctQuizIds
+      : {};
+    const answeredQuizIds = progress && progress.answeredQuizIds && typeof progress.answeredQuizIds === "object"
+      ? progress.answeredQuizIds
+      : {};
+    const candidates = shuffle(quizzes, `${identity.summaryKey}|${dateKey}`)
+      .filter((quiz) => {
+        const quizProgressKey = buildQuizProgressKey(quiz.id);
+        return correctQuizIds[quiz.id] !== true && correctQuizIds[quizProgressKey] !== true;
+      })
+      .filter((quiz) => answeredQuizIds[buildAnsweredQuizKey(dateKey, quiz.id)] !== true);
+    return candidates[0] || null;
+  }
+
+  async function readProgress(runtime, identity) {
+    const { collection, doc, getDoc, getDocs, limit, query, where } = runtime.firestoreModule;
+    const progressRef = doc(runtime.db, COLLECTIONS.progress, identity.progressIdSuffix);
+    const legacyProgressRef = doc(runtime.db, COLLECTIONS.progress, identity.idSuffix);
+    const refs = identity.progressIdSuffix === identity.idSuffix
+      ? [progressRef]
+      : [progressRef, legacyProgressRef];
+    const snapshots = await Promise.all(refs.map((ref) => getDoc(ref)));
+    const progressRows = snapshots
+      .filter((snapshot) => snapshot.exists())
+      .map((snapshot) => snapshot.data() || {});
+
+    if (identity.driverKey) {
+      const progressCollection = collection(runtime.db, COLLECTIONS.progress);
+      const driverProgressQuery = query(progressCollection, where("driverKey", "==", identity.driverKey), limit(50));
+      const driverProgressSnapshot = await getDocs(driverProgressQuery);
+      driverProgressSnapshot.docs.forEach((snapshotDoc) => {
+        progressRows.push(snapshotDoc.data() || {});
+      });
+    }
+
+    return progressRows.reduce((merged, data) => ({
+      ...merged,
+      ...data,
+      correctQuizIds: {
+        ...(merged.correctQuizIds || {}),
+        ...(data.correctQuizIds || {})
+      },
+      answeredQuizIds: {
+        ...(merged.answeredQuizIds || {}),
+        ...(data.answeredQuizIds || {})
+      }
+    }), {});
+  }
+
+  async function saveAnswer(runtime, identity, quiz, selectedIndex, dateKey) {
+    const {
+      doc,
+      increment,
+      runTransaction,
+      serverTimestamp
+    } = runtime.firestoreModule;
+    const answeredQuizKey = buildAnsweredQuizKey(dateKey, quiz.id);
+    const quizProgressKey = buildQuizProgressKey(quiz.id);
+    const answerRef = doc(runtime.db, COLLECTIONS.answers, `${identity.progressIdSuffix}_${dateKey}_${answeredQuizKey}`);
+    const progressRef = doc(runtime.db, COLLECTIONS.progress, identity.progressIdSuffix);
+    const summaryRef = doc(runtime.db, COLLECTIONS.points, buildSummaryDocId(identity));
+    const eventId = `daily_safety_quiz_${identity.progressIdSuffix}_${quizProgressKey}`;
+    const eventRef = doc(runtime.db, COLLECTIONS.points, buildEventDocId(eventId));
+    const isCorrect = selectedIndex === quiz.correctIndex;
+    const earnedPoint = isCorrect ? 1 : 0;
+    const nowIso = new Date().toISOString();
+    const result = {
+      alreadyAnswered: false,
+      isCorrect,
+      earnedPoint
+    };
+
+    await runTransaction(runtime.db, async (transaction) => {
+      const [answerSnapshot, eventSnapshot] = await Promise.all([
+        transaction.get(answerRef),
+        transaction.get(eventRef)
+      ]);
+      if (answerSnapshot.exists()) {
+        result.alreadyAnswered = true;
+        const data = answerSnapshot.data() || {};
+        result.isCorrect = data.isCorrect === true;
+        result.earnedPoint = Number(data.earnedPoint || 0);
+        return;
+      }
+
+      transaction.set(answerRef, {
+        date: dateKey,
+        quizId: quiz.id,
+        category: quiz.category,
+        selectedChoice: selectedIndex,
+        selectedChoiceText: quiz.choices[selectedIndex],
+        correctChoice: quiz.correctIndex,
+        correctChoiceText: quiz.choices[quiz.correctIndex],
+        isCorrect,
+        earnedPoint,
+        answeredAt: serverTimestamp(),
+        answeredAtLocal: nowIso,
+        driverKey: identity.driverKey,
+        driverName: identity.driverName,
+        vehicleKey: identity.vehicleKey,
+        vehicleNumber: identity.vehicleNumber,
+          progressIdSuffix: identity.progressIdSuffix,
+        uid: normalizeText(runtime.user && runtime.user.uid),
+        email: normalizeText(runtime.user && runtime.user.email)
+      });
+
+      const progressUpdate = {
+        driverKey: identity.driverKey,
+        driverName: identity.driverName,
+        vehicleKey: identity.vehicleKey,
+        vehicleNumber: identity.vehicleNumber,
+          progressIdSuffix: identity.progressIdSuffix,
+        lastAnsweredDate: dateKey,
+        lastQuizId: quiz.id,
+        answeredCount: increment(1),
+        updatedAt: serverTimestamp()
+      };
+      progressUpdate[`answeredQuizIds.${answeredQuizKey}`] = true;
+      if (isCorrect) {
+        progressUpdate[`correctQuizIds.${quizProgressKey}`] = true;
+        progressUpdate.correctCount = increment(1);
+      }
+      transaction.set(progressRef, progressUpdate, { merge: true });
+
+      if (isCorrect && !eventSnapshot.exists()) {
+        transaction.set(summaryRef, {
+          kind: "driver_points_summary",
+          driverKey: identity.driverKey,
+          driverName: identity.driverName,
+          vehicleKey: identity.vehicleKey,
+          vehicleNumber: identity.vehicleNumber,
+          progressIdSuffix: identity.progressIdSuffix,
+          totalPoints: increment(1),
+          dailySafetyQuizPoints: increment(1),
+          updatedAt: serverTimestamp(),
+          lastAwardAt: serverTimestamp(),
+          lastSource: "dailySafetyQuiz"
+        }, { merge: true });
+        transaction.set(eventRef, {
+          kind: "driver_points_event",
+          driverKey: identity.driverKey,
+          driverName: identity.driverName,
+          vehicleKey: identity.vehicleKey,
+          vehicleNumber: identity.vehicleNumber,
+          progressIdSuffix: identity.progressIdSuffix,
+          source: "dailySafetyQuiz",
+          points: 1,
+          targetDate: dateKey,
+          quizId: quiz.id,
+          category: quiz.category,
+          createdAt: serverTimestamp()
+        });
+      }
+    });
+
+    if (result.earnedPoint > 0 && window.DriverPoints && typeof window.DriverPoints.notifyPointAwarded === "function") {
+      window.DriverPoints.notifyPointAwarded();
+    }
+    return result;
+  }
+
+  function renderQuizDialog(quiz, onSubmit) {
+    ensureStyle();
+    return new Promise((resolve) => {
+      let selectedIndex = -1;
+      let submitted = false;
+      const dialog = document.createElement("dialog");
+      dialog.className = "daily-safety-quiz-dialog";
+      dialog.innerHTML = [
+        '<div class="daily-safety-quiz-panel">',
+        '<h2 class="daily-safety-quiz-title">今日の安全ワンポイント</h2>',
+        '<span class="daily-safety-quiz-meta">' + escapeHtml(quiz.category || "クイズ") + "</span>",
+        '<p class="daily-safety-quiz-question">' + escapeHtml(quiz.question) + "</p>",
+        '<div class="daily-safety-quiz-choices">',
+        quiz.choices.map((choice, index) => [
+          '<button class="daily-safety-quiz-choice" type="button" data-choice-index="' + String(index) + '">',
+          '<span class="daily-safety-quiz-choice-mark" aria-hidden="true"></span>',
+          '<span>' + escapeHtml(choice) + "</span>",
+          "</button>"
+        ].join("")).join(""),
+        "</div>",
+        '<div class="daily-safety-quiz-actions">',
+        '<button class="daily-safety-quiz-button" type="button" data-submit disabled>この答えで決定</button>',
+        "</div>",
+        "</div>"
+      ].join("");
+      const submitButton = dialog.querySelector("[data-submit]");
+      const choiceButtons = Array.from(dialog.querySelectorAll("[data-choice-index]"));
+      choiceButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          if (submitted) return;
+          selectedIndex = Number(button.dataset.choiceIndex);
+          choiceButtons.forEach((choiceButton) => {
+            const active = Number(choiceButton.dataset.choiceIndex) === selectedIndex;
+            choiceButton.classList.toggle("is-selected", active);
+            choiceButton.setAttribute("aria-pressed", active ? "true" : "false");
+          });
+          submitButton.disabled = false;
+        });
+      });
+      submitButton.addEventListener("click", async () => {
+        if (selectedIndex < 0 || submitted) return;
+        submitted = true;
+        submitButton.disabled = true;
+        submitButton.textContent = "送信中...";
+        try {
+          const result = await onSubmit(selectedIndex);
+          renderResult(dialog, quiz, result, () => {
+            closeDialog(dialog);
+            resolve(result);
+          });
+        } catch (error) {
+          console.warn("Failed to submit daily safety quiz:", error);
+          renderResult(dialog, quiz, {
+            isCorrect: false,
+            earnedPoint: 0,
+            submitError: "回答を保存できませんでした。通信状態を確認して、もう一度お試しください。"
+          }, () => {
+            closeDialog(dialog);
+            resolve(null);
+          });
+        }
+      });
+      document.body.appendChild(dialog);
+      showDialog(dialog);
+    });
+  }
+
+  function renderResult(dialog, quiz, result, onDone) {
+    const correct = result && result.isCorrect === true;
+    dialog.innerHTML = [
+      '<div class="daily-safety-quiz-panel daily-safety-quiz-result">',
+      '<h2 class="daily-safety-quiz-title">今日の安全ワンポイント</h2>',
+      '<p class="daily-safety-quiz-result-heading">' + escapeHtml(
+        result && result.submitError
+          ? "回答を保存できませんでした"
+          : correct
+            ? "正解です。1ポイント獲得しました"
+            : "今回はポイントなし"
+      ) + "</p>",
+      correct || (result && result.submitError) ? "" : [
+        '<div class="daily-safety-quiz-correct-answer">',
+        "正解: " + escapeHtml(quiz.choices[quiz.correctIndex]),
+        "</div>",
+        '<p class="daily-safety-quiz-explanation">' + escapeHtml(quiz.explanation || "") + "</p>"
+      ].join(""),
+      result && result.submitError ? '<p class="daily-safety-quiz-explanation">' + escapeHtml(result.submitError) + "</p>" : "",
+      '<div class="daily-safety-quiz-actions">',
+      '<button class="daily-safety-quiz-button" type="button">完了</button>',
+      "</div>",
+      "</div>"
+    ].join("");
+    dialog.querySelector("button").addEventListener("click", onDone);
+  }
+
+  async function showAfterInspection(options = {}) {
+    if (!await shouldShowQuiz()) {
+      return { shown: false, reason: "disabled" };
+    }
+    const identity = buildIdentity(options.driverName, options.vehicleNumber);
+    if (!identity.driverKey || !identity.vehicleKey) {
+      return { shown: false, reason: "missing_identity" };
+    }
+
+    try {
+      const runtime = await ensureRuntime();
+      const dateKey = buildLocalDateKey();
+      const progress = await readProgress(runtime, identity);
+      const quiz = await selectQuiz(runtime, identity, progress, dateKey);
+      if (!quiz) {
+        return { shown: false, reason: "no_quiz" };
+      }
+
+      await renderQuizDialog(quiz, (selectedIndex) => saveAnswer(runtime, identity, quiz, selectedIndex, dateKey));
+      return { shown: true, reason: "answered" };
+    } catch (error) {
+      console.warn("Failed to show daily safety quiz:", error);
+      await renderDoneDialog("クイズを読み込めませんでした。通信状態とログイン状態を確認してください。");
+      return { shown: true, reason: "error", error };
+    }
+  }
+
+  window.DailySafetyQuiz = Object.freeze({
+    loadSettings,
+    shouldShowCompletionImage,
+    showAfterInspection
+  });
+})();

--- a/sinyuubuturyuu/driver-points/driver-points.js
+++ b/sinyuubuturyuu/driver-points/driver-points.js
@@ -173,6 +173,11 @@
     window.localStorage.setItem(LAST_AWARD_KEY, new Date().toISOString());
   }
 
+  function notifyPointAwarded() {
+    markPointAwarded();
+    requestBadgeRefresh({ force: true, reason: 'external_award', delayMs: 0 });
+  }
+
   function getCachedSummary(identity) {
     const entry = uiState.summaryCache.get(identity.summaryKey);
     if (!entry) {
@@ -521,12 +526,16 @@
     }
 
     const data = snapshot.exists() ? snapshot.data() : {};
+    const points = Number(data.totalPoints || 0);
+    const quizPoints = Number(data.dailySafetyQuizPoints || 0);
     const summary = {
       ok: true,
       enabled: true,
       driverName: identity.driverName,
       vehicleNumber: identity.vehicleNumber,
-      points: Number(data.totalPoints || 0)
+      points,
+      inspectionPoints: Math.max(0, points - quizPoints),
+      quizPoints
     };
     setCachedSummary(identity, summary);
     return summary;
@@ -690,6 +699,10 @@
     style.textContent = [
       ".driver-points-inline { display: inline-flex; align-items: center; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }",
       ".driver-points-name { min-width: 0; }",
+      ".driver-points-selection-row { flex-wrap: wrap; }",
+      ".driver-points-selection-row #currentDriverName { white-space: nowrap; word-break: keep-all; }",
+      ".driver-points-row { display: flex; justify-content: flex-end; flex-basis: 100%; width: 100%; margin-top: 6px; }",
+      ".driver-points-row[hidden] { display: none !important; }",
       ".driver-points-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 60px; min-height: 28px; padding: 4px 10px; border-radius: 999px; background: rgba(23, 105, 210, 0.12); color: var(--primary, #1769d2); font-size: 0.82rem; font-weight: 800; line-height: 1; }",
       ".driver-points-badge[hidden] { display: none !important; }",
       ".driver-points-section-head { display: flex; align-items: center; justify-content: flex-start; gap: 8px; flex-wrap: wrap; }",
@@ -806,14 +819,30 @@
     }
     ensureStyle();
 
-    let wrapper = nameEl.parentElement;
-    if (!wrapper || !wrapper.classList.contains("driver-points-inline")) {
-      wrapper = document.createElement("span");
-      wrapper.className = "current-selection-value driver-points-inline";
-      nameEl.parentNode.insertBefore(wrapper, nameEl);
-      wrapper.appendChild(nameEl);
-      nameEl.classList.remove("current-selection-value");
-      nameEl.classList.add("driver-points-name");
+    const oldWrapper = nameEl.parentElement && nameEl.parentElement.classList.contains("driver-points-inline")
+      ? nameEl.parentElement
+      : null;
+    if (oldWrapper && oldWrapper.parentNode) {
+      oldWrapper.parentNode.insertBefore(nameEl, oldWrapper);
+      oldWrapper.remove();
+    }
+
+    const selectionRow = nameEl.closest(".current-selection-row") || nameEl.parentElement;
+    if (selectionRow) {
+      selectionRow.classList.add("driver-points-selection-row");
+    }
+    nameEl.classList.add("current-selection-value");
+    nameEl.classList.remove("driver-points-name");
+
+    let row = document.getElementById("currentDriverPointsRow");
+    if (!row) {
+      row = document.createElement("span");
+      row.id = "currentDriverPointsRow";
+      row.className = "driver-points-row";
+      row.hidden = true;
+      nameEl.insertAdjacentElement("afterend", row);
+    } else if (row.previousElementSibling !== nameEl) {
+      nameEl.insertAdjacentElement("afterend", row);
     }
 
     let badge = document.getElementById("currentDriverPoints");
@@ -822,10 +851,12 @@
       badge.id = "currentDriverPoints";
       badge.className = "driver-points-badge";
       badge.hidden = true;
-      wrapper.appendChild(badge);
+      row.appendChild(badge);
+    } else if (badge.parentElement !== row) {
+      row.appendChild(badge);
     }
 
-    return { nameEl, vehicleEl, badge };
+    return { nameEl, vehicleEl, row, badge };
   }
 
   function getCurrentSelection(elements) {
@@ -992,6 +1023,10 @@
     if (!badge) {
       return;
     }
+    const row = document.getElementById("currentDriverPointsRow");
+    if (row) {
+      row.hidden = true;
+    }
     badge.hidden = true;
     badge.textContent = "";
     badge.removeAttribute("title");
@@ -1034,6 +1069,9 @@
     }
 
     const refreshToken = ++uiState.badgeRefreshToken;
+    if (elements.row) {
+      elements.row.hidden = false;
+    }
     elements.badge.hidden = false;
     elements.badge.textContent = "...";
     elements.badge.setAttribute("aria-busy", "true");
@@ -1049,7 +1087,7 @@
         hideBadge();
         return;
       }
-      elements.badge.textContent = `${summary.points}pt`;
+      elements.badge.textContent = `点検 ${summary.inspectionPoints || 0}pt / クイズ ${summary.quizPoints || 0}pt`;
       elements.badge.title = `${summary.vehicleNumber} / ${summary.driverName} のポイント`;
       uiState.lastBadgeSyncAt = Date.now();
     } catch (error) {
@@ -1148,6 +1186,7 @@
     readDriverPoints,
     awardDailyInspection,
     awardMonthlyTireInspection,
+    notifyPointAwarded,
     mountLauncherUi
   });
 

--- a/sinyuubuturyuu/getujinitijyoutenkenhyou/app.js
+++ b/sinyuubuturyuu/getujinitijyoutenkenhyou/app.js
@@ -450,8 +450,7 @@ async function submitSend(sendPlan = null, maintenanceNote = "") {
     });
 
     if (!completedAllMonths) {
-      await showSendFarewell();
-      returnToLauncherHome();
+      await runPostInspectionCompletionFlow();
     }
   } catch (error) {
     setInspectionStatus(`送信に失敗しました: ${error.message}`, true);
@@ -1067,6 +1066,36 @@ async function showSendFarewell(options = {}) {
   await new Promise((resolve) => setTimeout(resolve, 1800));
 }
 
+async function runPostInspectionCompletionFlow(options = {}) {
+  const dailySafetyQuiz = window.DailySafetyQuiz;
+  const shouldShowImage = !dailySafetyQuiz
+    || typeof dailySafetyQuiz.shouldShowCompletionImage !== "function"
+    || await dailySafetyQuiz.shouldShowCompletionImage();
+
+  if (shouldShowImage) {
+    await showSendFarewell(options.image || {});
+  }
+
+  await showDailySafetyQuizAfterInspection();
+  returnToLauncherHome();
+}
+
+async function showDailySafetyQuizAfterInspection() {
+  const dailySafetyQuiz = window.DailySafetyQuiz;
+  if (!dailySafetyQuiz || typeof dailySafetyQuiz.showAfterInspection !== "function") {
+    return;
+  }
+
+  try {
+    await dailySafetyQuiz.showAfterInspection({
+      source: "dailyInspection",
+      driverName: String(state.session?.driver || state.sharedSelection?.driver || "").trim(),
+      vehicleNumber: String(state.session?.vehicle || state.sharedSelection?.vehicle || "").trim()
+    });
+  } catch (error) {
+    console.warn("Failed to run daily safety quiz after daily inspection:", error);
+  }
+}
 async function showMonthlyCompleteAndReturnHome() {
   if (state.monthlyCompleteFlowRunning) {
     return;
@@ -1078,11 +1107,12 @@ async function showMonthlyCompleteAndReturnHome() {
   const previousAlt = image ? image.getAttribute("alt") || "" : "";
 
   try {
-    await showSendFarewell({
-      src: MONTHLY_COMPLETE_IMAGE_SRC,
-      alt: MONTHLY_COMPLETE_IMAGE_ALT
+    await runPostInspectionCompletionFlow({
+      image: {
+        src: MONTHLY_COMPLETE_IMAGE_SRC,
+        alt: MONTHLY_COMPLETE_IMAGE_ALT
+      }
     });
-    returnToLauncherHome();
   } finally {
     if (image) {
       image.src = previousSrc;
@@ -1935,5 +1965,3 @@ function canAccessServiceWorkerApis() {
 
   return window.location.protocol === "http:" || window.location.protocol === "https:";
 }
-
-

--- a/sinyuubuturyuu/getujinitijyoutenkenhyou/index.html
+++ b/sinyuubuturyuu/getujinitijyoutenkenhyou/index.html
@@ -132,6 +132,7 @@
   <script src="../driver-points/driver-points.js?v=20260423b"></script>
   <script src="./firebase-config.js?v=20260322-1"></script>
   <script src="../auth/firebase-auth.js?v=20260330a"></script>
+  <script src="../daily-safety-quiz/daily-safety-quiz.js?v=20260628b"></script>
   <script src="./app.js?v=20260518a"></script>
 </body>
 </html>

--- a/sinyuubuturyuu/getujitiretenkenhyou/app.js
+++ b/sinyuubuturyuu/getujitiretenkenhyou/app.js
@@ -1952,15 +1952,46 @@
         await new Promise((resolve) => setTimeout(resolve, 1800));
       }
 
+      async function runPostInspectionCompletionFlow(snapshot, options = {}) {
+        const dailySafetyQuiz = window.DailySafetyQuiz;
+        const shouldShowImage = !dailySafetyQuiz
+          || typeof dailySafetyQuiz.shouldShowCompletionImage !== "function"
+          || await dailySafetyQuiz.shouldShowCompletionImage();
+
+        if (shouldShowImage) {
+          await showSendFarewell(options.image || {});
+        }
+
+        await showDailySafetyQuizAfterInspection(snapshot);
+        returnToLauncherHome();
+      }
+
+      async function showDailySafetyQuizAfterInspection(snapshot) {
+        const dailySafetyQuiz = window.DailySafetyQuiz;
+        if (!dailySafetyQuiz || typeof dailySafetyQuiz.showAfterInspection !== "function") {
+          return;
+        }
+
+        try {
+          await dailySafetyQuiz.showAfterInspection({
+            source: "monthlyTireInspection",
+            driverName: normalizeDriverName(snapshot && snapshot.driverName),
+            vehicleNumber: String(snapshot && snapshot.vehicleNumber ? snapshot.vehicleNumber : "").trim()
+          });
+        } catch (error) {
+          console.warn("Failed to run daily safety quiz after monthly tire inspection:", error);
+        }
+      }
       async function showMonthlyCompleteAndReturnHome() {
         if (monthlyCompleteFlowRunning) return;
         monthlyCompleteFlowRunning = true;
         try {
-          await showSendFarewell({
-            src: MONTHLY_COMPLETE_IMAGE_SRC,
-            alt: MONTHLY_COMPLETE_IMAGE_ALT
+          await runPostInspectionCompletionFlow(current, {
+            image: {
+              src: MONTHLY_COMPLETE_IMAGE_SRC,
+              alt: MONTHLY_COMPLETE_IMAGE_ALT
+            }
           });
-          returnToLauncherHome();
         } finally {
           monthlyCompleteFlowRunning = false;
         }
@@ -2040,8 +2071,7 @@
           await showMonthlyCompleteAndReturnHome();
           return;
         }
-        await showSendFarewell();
-        returnToLauncherHome();
+        await runPostInspectionCompletionFlow(previousSnapshot);
       }
 
       async function awardDriverPointsForMonthlyTire(snapshot) {
@@ -2574,4 +2604,3 @@
         window.alert(`初期化に失敗しました: ${error.message}`);
       });
     })();
-

--- a/sinyuubuturyuu/getujitiretenkenhyou/index.html
+++ b/sinyuubuturyuu/getujitiretenkenhyou/index.html
@@ -204,6 +204,7 @@
   <script src="../driver-points/driver-points.js?v=20260423b"></script>
   <script src="./firebase/firebase-config.js?v=20260322-1"></script>
   <script src="../auth/firebase-auth.js?v=20260330a"></script>
+  <script src="../daily-safety-quiz/daily-safety-quiz.js?v=20260628b"></script>
   <script src="./firebase/firebase-cloud-sync.js?v=20260423c"></script>
   <script src="./app.js?v=20260601a"></script>
 </body>

--- a/sinyuubuturyuu/index.html
+++ b/sinyuubuturyuu/index.html
@@ -12,7 +12,7 @@
   <link rel="manifest" href="./manifest.webmanifest">
   <link rel="icon" href="./sinyuubuturyuu-icon.png" type="image/png">
   <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
-  <link rel="stylesheet" href="./launcher.css?v=20260418a">
+  <link rel="stylesheet" href="./launcher.css?v=20260627e">
 </head>
 <body>
   <main class="launcher">
@@ -92,6 +92,20 @@
 
         <section class="settings-section">
           <div class="section-head">
+            <h3>点検後の表示</h3>
+          </div>
+          <label class="field-check">
+            <input id="completionImageDisplayEnabled" type="checkbox">
+            <span>点検完了後の画像を表示する</span>
+          </label>
+          <label class="field-check">
+            <input id="dailySafetyQuizDisplayEnabled" type="checkbox">
+            <span>点検後にクイズを表示する</span>
+          </label>
+        </section>
+
+        <section class="settings-section">
+          <div class="section-head">
             <h3>車両番号</h3>
           </div>
           <div class="field">
@@ -139,7 +153,7 @@
   <script src="./getujitiretenkenhyou/firebase/firebase-config.js?v=20260322-1"></script>
   <script src="./getujitiretenkenhyou/firebase/firebase-cloud-sync.js?v=20260423c"></script>
   <script src="./auth/firebase-auth.js?v=20260330a"></script>
-  <script src="./launcher.js?v=20260418a"></script>
+  <script src="./launcher.js?v=20260627e"></script>
 </body>
 </html>
 

--- a/sinyuubuturyuu/launcher.css
+++ b/sinyuubuturyuu/launcher.css
@@ -301,6 +301,27 @@ body {
   font-weight: 700;
 }
 
+.field-check {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.field-check + .field-check {
+  border-top: 1px solid var(--line);
+}
+
+.field-check input {
+  width: 22px;
+  height: 22px;
+  accent-color: var(--primary);
+  flex: 0 0 auto;
+}
+
 .field input,
 .field-select {
   width: 100%;

--- a/sinyuubuturyuu/launcher.js
+++ b/sinyuubuturyuu/launcher.js
@@ -58,6 +58,11 @@ const DAILY_INSPECTION_MAX_SELECTABLE_MONTH_COUNT = 4;
 const DAILY_INSPECTION_FIREBASE_REQUIRED_KEYS = ["apiKey", "authDomain", "projectId", "appId"];
 const DAILY_INSPECTION_CHECK_SEQUENCE = ["", "レ", "×", "▲"];
 const DAILY_INSPECTION_HOLIDAY_CHECK = "休";
+const DAILY_SAFETY_QUIZ_DISPLAY_SETTINGS_KEY = "sinyuubuturyuu.dailySafetyQuizDisplaySettings.v1";
+const DEFAULT_DAILY_SAFETY_QUIZ_DISPLAY_SETTINGS = Object.freeze({
+  quizEnabled: true,
+  completionImageEnabled: true,
+});
 const DAILY_INSPECTION_ITEM_IDS = Object.freeze([
   "brake_pedal",
   "brake_fluid",
@@ -143,6 +148,8 @@ const elements = {
   closeSettingsButton: document.getElementById("closeSettingsButton"),
   confirmSettingsButton: document.getElementById("confirmSettingsButton"),
   themeMode: document.getElementById("themeMode"),
+  completionImageDisplayEnabled: document.getElementById("completionImageDisplayEnabled"),
+  dailySafetyQuizDisplayEnabled: document.getElementById("dailySafetyQuizDisplayEnabled"),
   vehicleSelect: document.getElementById("vehicleSelect"),
   driverAutoDisplay: document.getElementById("driverAutoDisplay"),
   truckTypeAutoDisplay: document.getElementById("truckTypeAutoDisplay"),
@@ -451,8 +458,42 @@ function renderCurrentSelection() {
 
 function renderSettings() {
   elements.themeMode.value = state.shared.theme;
+  renderDisplaySettings();
   renderVehicleSelect();
   renderAssignedProfile();
+}
+
+function readDailySafetyQuizDisplaySettings() {
+  try {
+    const raw = window.localStorage.getItem(DAILY_SAFETY_QUIZ_DISPLAY_SETTINGS_KEY);
+    const data = raw ? JSON.parse(raw) : {};
+    return {
+      quizEnabled: data.quizEnabled !== false,
+      completionImageEnabled: data.completionImageEnabled !== false,
+    };
+  } catch {
+    return { ...DEFAULT_DAILY_SAFETY_QUIZ_DISPLAY_SETTINGS };
+  }
+}
+
+function saveDailySafetyQuizDisplaySettings(patch) {
+  const current = readDailySafetyQuizDisplaySettings();
+  const next = {
+    ...current,
+    ...(patch || {}),
+  };
+  window.localStorage.setItem(DAILY_SAFETY_QUIZ_DISPLAY_SETTINGS_KEY, JSON.stringify(next));
+  return next;
+}
+
+function renderDisplaySettings() {
+  const settings = readDailySafetyQuizDisplaySettings();
+  if (elements.completionImageDisplayEnabled) {
+    elements.completionImageDisplayEnabled.checked = settings.completionImageEnabled !== false;
+  }
+  if (elements.dailySafetyQuizDisplayEnabled) {
+    elements.dailySafetyQuizDisplayEnabled.checked = settings.quizEnabled !== false;
+  }
 }
 
 function applyTheme() {
@@ -846,6 +887,24 @@ function bindEvents() {
     renderAll();
     setStatus("表示モードを更新しました。");
   });
+  if (elements.completionImageDisplayEnabled) {
+    elements.completionImageDisplayEnabled.addEventListener("change", (event) => {
+      saveDailySafetyQuizDisplaySettings({
+        completionImageEnabled: Boolean(event.target.checked),
+      });
+      renderDisplaySettings();
+      setStatus("\u70b9\u691c\u5f8c\u306e\u753b\u50cf\u8868\u793a\u8a2d\u5b9a\u3092\u66f4\u65b0\u3057\u307e\u3057\u305f\u3002");
+    });
+  }
+  if (elements.dailySafetyQuizDisplayEnabled) {
+    elements.dailySafetyQuizDisplayEnabled.addEventListener("change", (event) => {
+      saveDailySafetyQuizDisplaySettings({
+        quizEnabled: Boolean(event.target.checked),
+      });
+      renderDisplaySettings();
+      setStatus("\u70b9\u691c\u5f8c\u306e\u30af\u30a4\u30ba\u8868\u793a\u8a2d\u5b9a\u3092\u66f4\u65b0\u3057\u307e\u3057\u305f\u3002");
+    });
+  }
   if (elements.vehicleSelect) {
     elements.vehicleSelect.addEventListener("change", (event) => {
       const value = String(event.target.value || "").trim();

--- a/sinyuubuturyuu/sw.js
+++ b/sinyuubuturyuu/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "sinyuubuturyuu-launcher-v25";
+const CACHE_NAME = "sinyuubuturyuu-launcher-v34";
 const APP_SHELL = [
   "./",
   "./index.html",
@@ -6,6 +6,7 @@ const APP_SHELL = [
   "./launcher.js",
   "./shared-settings.js?v=20260405a",
   "./driver-points/driver-points.js?v=20260423b",
+  "./daily-safety-quiz/daily-safety-quiz.js?v=20260628b",
   "./manifest.webmanifest",
   "./sinyuubuturyuu-icon.png",
   "./apple-touch-icon.png",
@@ -19,6 +20,7 @@ const NETWORK_FIRST_PATH_SUFFIXES = [
   "/launcher.js",
   "/shared-settings.js",
   "/driver-points/driver-points.js",
+  "/daily-safety-quiz/daily-safety-quiz.js",
   "/manifest.webmanifest",
 ];
 


### PR DESCRIPTION
## Summary
- add a draft daily safety quiz flow after monthly tire and daily inspection completion
- add PC quiz management screen for creating, editing, deleting, and enabling questions
- split inspection and quiz points in driver point displays

## Notes
- This is intentionally a Draft PR because quiz history, point deletion, and cancellation behavior still need design cleanup before production use.
- Do not merge as-is.

## Validation
- node --check sinyuubuturyuu/daily-safety-quiz/daily-safety-quiz.js
- node --check sinyuubuturyuu-pc/driver-points-kanri/daily-safety-quiz.js
- node --check sinyuubuturyuu/driver-points/driver-points.js
- node --check sinyuubuturyuu-pc/driver-points-kanri/driver-points-kanri.js
- node --check inspection app scripts, launcher.js, and sw.js
- git diff --check