### PR TITLE
点検の年度内未入力月判定を統一

### DIFF
--- a/sinyuubuturyuu/getujinitijyoutenkenhyou/app.js
+++ b/sinyuubuturyuu/getujinitijyoutenkenhyou/app.js
@@ -9,7 +9,7 @@ const HOLIDAY_CHECK = "休";
 const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
 const STORAGE_NAMESPACE = "monthly_inspection_app_v1";
 const MIN_SELECTABLE_MONTH = "2025-10";
-const MAX_SELECTABLE_MONTH_COUNT = 4;
+const RECENT_MONTH_COUNT = 4;
 const THEME_COLORS = Object.freeze({
   light: "#f3f5f8",
   dark: "#0f1722"
@@ -19,7 +19,7 @@ const INSPECTION_GUIDE_MESSAGE = `未入力日のみ表示しています。
 タップすると空欄 → レ → × → ▲と入力されます。　
 休みの日は日付を押して休みとしてください。もう一度押すと解除できます。
 一日分以上を入力したら上の送信ボタンを押してください。`;
-const APP_VERSION = "20260727a";
+const APP_VERSION = "20260801a";
 const MONTHLY_COMPLETE_IMAGE_SRC = "./icons/monthly-complete.png";
 const MONTHLY_COMPLETE_IMAGE_ALT = "今月分はすべて完了しました。明日もよろしくお願いします。";
 const SEND_FAREWELL_IMAGE_SRCS = Object.freeze([
@@ -1841,23 +1841,37 @@ function syncTargetMonth(preferredMonth = getCurrentYearMonth()) {
   syncDraftForTargetMonth();
 }
 
-function getSelectableMonths() {
-  const currentMonth = getCurrentYearMonth();
+function getInspectionTargetMonthKeys(date = new Date()) {
+  if (sharedSettings && typeof sharedSettings.buildInspectionTargetMonthKeys === "function") {
+    return sharedSettings.buildInspectionTargetMonthKeys(date, {
+      minimumMonthCount: RECENT_MONTH_COUNT,
+      fiscalYearStartMonth: 4,
+      minimumMonthKey: MIN_SELECTABLE_MONTH
+    });
+  }
+
+  const currentMonth = toYearMonth(date.getFullYear(), date.getMonth() + 1);
   if (compareYearMonth(currentMonth, MIN_SELECTABLE_MONTH) < 0) {
     return [currentMonth];
   }
-
-  const months = [];
-  let cursor = getSelectableMonthStart(currentMonth);
-
-  while (compareYearMonth(cursor, currentMonth) <= 0) {
-    if (getPendingDays(cursor).length > 0) {
-      months.push(cursor);
-    }
-    cursor = addMonths(cursor, 1);
+  const fiscalYearStart = date.getMonth() + 1 >= 4 ? date.getFullYear() : date.getFullYear() - 1;
+  const fiscalStart = toYearMonth(fiscalYearStart, 4);
+  const rollingStart = addMonths(currentMonth, -(RECENT_MONTH_COUNT - 1));
+  let cursor = compareYearMonth(rollingStart, fiscalStart) < 0 ? rollingStart : fiscalStart;
+  if (compareYearMonth(cursor, MIN_SELECTABLE_MONTH) < 0) {
+    cursor = MIN_SELECTABLE_MONTH;
   }
 
-  return months;
+  const monthKeys = [];
+  while (compareYearMonth(cursor, currentMonth) <= 0) {
+    monthKeys.push(cursor);
+    cursor = addMonths(cursor, 1);
+  }
+  return monthKeys;
+}
+
+function getSelectableMonths() {
+  return getInspectionTargetMonthKeys().filter((month) => getPendingDays(month).length > 0);
 }
 
 function clearCompletionMarker() {
@@ -1869,8 +1883,8 @@ function clearCompletionMarker() {
 }
 
 function getSelectableMonthStart(currentMonth) {
-  const rollingStart = addMonths(currentMonth, -(MAX_SELECTABLE_MONTH_COUNT - 1));
-  return compareYearMonth(rollingStart, MIN_SELECTABLE_MONTH) < 0 ? MIN_SELECTABLE_MONTH : rollingStart;
+  const { year, month } = parseYearMonth(currentMonth);
+  return getInspectionTargetMonthKeys(new Date(year, month - 1, 1))[0] || currentMonth;
 }
 
 function resolveSelectableMonth(preferredMonth, availableMonths) {

--- a/sinyuubuturyuu/getujinitijyoutenkenhyou/index.html
+++ b/sinyuubuturyuu/getujinitijyoutenkenhyou/index.html
@@ -127,12 +127,12 @@
 
   </main>
 
-  <script src="../shared-settings.js"></script>
+  <script src="../shared-settings.js?v=20260801a"></script>
   <script src="../shared-no-zoom.js"></script>
   <script src="../driver-points/driver-points.js?v=20260727a"></script>
   <script src="./firebase-config.js?v=20260727a"></script>
   <script src="../auth/firebase-auth.js?v=20260727a"></script>
-  <script src="./app.js?v=20260727a"></script>
+  <script src="./app.js?v=20260801a"></script>
 </body>
 </html>
 

--- a/sinyuubuturyuu/getujinitijyoutenkenhyou/sw.js
+++ b/sinyuubuturyuu/getujinitijyoutenkenhyou/sw.js
@@ -1,4 +1,4 @@
-const APP_VERSION = "20260727a";
+const APP_VERSION = "20260801a";
 const CACHE_NAME = `monthly-inspection-shell-${APP_VERSION}`;
 const APP_SHELL = [
   "./",

--- a/sinyuubuturyuu/getujitiretenkenhyou/app.js
+++ b/sinyuubuturyuu/getujitiretenkenhyou/app.js
@@ -18,7 +18,7 @@
       const LAST_COMMIT_PUSHED_AT = "2026-03-01 21:33";
       const MONTHLY_COMPLETE_IMAGE_SRC = "icons/monthly-complete.png";
       const MONTHLY_COMPLETE_IMAGE_ALT = "今月分はすべて入力済みです。来月もよろしくお願いします。";
-      const MAX_SELECTABLE_MONTH_COUNT = 4;
+      const RECENT_MONTH_COUNT = 4;
       const SEND_FAREWELL_IMAGE_SRCS = Object.freeze([
         "icons/send-farewell.png?v=20260315-15",
         "icons/send-farewell-02.png?v=20260518a"
@@ -286,9 +286,26 @@
         return parsed ? `${parsed.year}年${parsed.month}月分` : "未選択";
       };
       const buildSelectableMonthKeys = (date = new Date()) => {
+        if (sharedSettings && typeof sharedSettings.buildInspectionTargetMonthKeys === "function") {
+          return sharedSettings.buildInspectionTargetMonthKeys(date, {
+            minimumMonthCount: RECENT_MONTH_COUNT,
+            fiscalYearStartMonth: 4
+          });
+        }
+
         const keys = [];
-        const startDate = new Date(date.getFullYear(), date.getMonth() - (MAX_SELECTABLE_MONTH_COUNT - 1), 1);
-        for (let offset = 0; offset < MAX_SELECTABLE_MONTH_COUNT; offset += 1) {
+        const currentMonth = date.getMonth() + 1;
+        const fiscalYearStart = currentMonth >= 4 ? date.getFullYear() : date.getFullYear() - 1;
+        const fiscalStartDate = new Date(fiscalYearStart, 3, 1);
+        const rollingStartDate = new Date(date.getFullYear(), date.getMonth() - (RECENT_MONTH_COUNT - 1), 1);
+        const startDate = rollingStartDate < fiscalStartDate ? rollingStartDate : fiscalStartDate;
+        const monthCount = (
+          (date.getFullYear() - startDate.getFullYear()) * 12
+          + date.getMonth()
+          - startDate.getMonth()
+          + 1
+        );
+        for (let offset = 0; offset < monthCount; offset += 1) {
           const targetDate = new Date(startDate.getFullYear(), startDate.getMonth() + offset, 1);
           keys.push(normalizeMonthKey(`${targetDate.getFullYear()}-${String(targetDate.getMonth() + 1).padStart(2, "0")}`));
         }

--- a/sinyuubuturyuu/getujitiretenkenhyou/index.html
+++ b/sinyuubuturyuu/getujitiretenkenhyou/index.html
@@ -200,12 +200,12 @@
     <img id="sendFarewellImage" src="icons/send-farewell.png?v=20260315-15" alt="送信ありがとうございました。ご安全に。">
   </div>
   <script src="../shared-no-zoom.js"></script>
-  <script src="../shared-settings.js?v=20260727a"></script>
+  <script src="../shared-settings.js?v=20260801a"></script>
   <script src="../driver-points/driver-points.js?v=20260727a"></script>
   <script src="./firebase/firebase-config.js?v=20260727a"></script>
   <script src="../auth/firebase-auth.js?v=20260727a"></script>
   <script src="./firebase/firebase-cloud-sync.js?v=20260727a"></script>
-  <script src="./app.js?v=20260601a"></script>
+  <script src="./app.js?v=20260801a"></script>
 </body>
 </html>
 

--- a/sinyuubuturyuu/getujitiretenkenhyou/sw.js
+++ b/sinyuubuturyuu/getujitiretenkenhyou/sw.js
@@ -1,9 +1,9 @@
-const CACHE_NAME = "monthly-tire-check-v56";
+const CACHE_NAME = "monthly-tire-check-v57";
 const ASSETS = [
   "./",
   "./index.html",
   "./styles.css?v=20260312-2",
-  "./app.js?v=20260601a",
+  "./app.js?v=20260801a",
   "./manifest.webmanifest",
   "./sw.js",
   "./firebase/firebase-config.js?v=20260727a",

--- a/sinyuubuturyuu/index.html
+++ b/sinyuubuturyuu/index.html
@@ -135,13 +135,13 @@
     <img id="sendFarewellImage" src="./getujitiretenkenhyou/icons/monthly-complete.png" alt="Monthly inspection complete.">
   </div>
 
-  <script src="./shared-settings.js?v=20260727a"></script>
+  <script src="./shared-settings.js?v=20260801a"></script>
   <script src="./shared-no-zoom.js"></script>
   <script src="./getujitiretenkenhyou/firebase/firebase-config.js?v=20260727a"></script>
   <script src="./auth/firebase-auth.js?v=20260727a"></script>
   <script src="./getujitiretenkenhyou/firebase/firebase-cloud-sync.js?v=20260727a"></script>
   <script src="./driver-points/driver-points.js?v=20260727a"></script>
-  <script src="./launcher.js?v=20260727a"></script>
+  <script src="./launcher.js?v=20260801a"></script>
 </body>
 </html>
 

--- a/sinyuubuturyuu/launcher.js
+++ b/sinyuubuturyuu/launcher.js
@@ -60,7 +60,7 @@ const DAILY_INSPECTION_APP_SETTINGS = Object.freeze({
 });
 const DAILY_INSPECTION_STORAGE_NAMESPACE = "monthly_inspection_app_v1";
 const DAILY_INSPECTION_MIN_SELECTABLE_MONTH = "2025-10";
-const DAILY_INSPECTION_MAX_SELECTABLE_MONTH_COUNT = 4;
+const DAILY_INSPECTION_RECENT_MONTH_COUNT = 4;
 const DAILY_INSPECTION_FIREBASE_REQUIRED_KEYS = ["apiKey", "authDomain", "projectId", "appId"];
 const DAILY_INSPECTION_CHECK_SEQUENCE = ["", "レ", "×", "▲"];
 const DAILY_INSPECTION_HOLIDAY_CHECK = "休";
@@ -956,18 +956,44 @@ function buildCloudPayload() {
   };
 }
 
-function buildSelectableMonthKeys(date = new Date()) {
+function buildSelectableMonthKeys(date = new Date(), options = {}) {
+  if (sharedSettings && typeof sharedSettings.buildInspectionTargetMonthKeys === "function") {
+    return sharedSettings.buildInspectionTargetMonthKeys(date, {
+      minimumMonthCount: 4,
+      fiscalYearStartMonth: 4,
+      ...options,
+    });
+  }
+
   const keys = [];
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
+  const minimumMonthCount = Number.isInteger(options.minimumMonthCount) && options.minimumMonthCount > 0
+    ? options.minimumMonthCount
+    : 4;
+  const fiscalYearStart = month >= 4 ? year : year - 1;
+  const fiscalStartDate = new Date(fiscalYearStart, 3, 1);
+  const rollingStartDate = new Date(year, month - minimumMonthCount, 1);
+  let startDate = rollingStartDate < fiscalStartDate ? rollingStartDate : fiscalStartDate;
+  const minimumMonth = /^(\d{4})-(\d{2})$/.exec(String(options.minimumMonthKey || ""));
 
-  for (let currentMonth = month; currentMonth >= 1; currentMonth -= 1) {
-    keys.push(`${year}-${String(currentMonth).padStart(2, "0")}`);
+  if (minimumMonth) {
+    const minimumDate = new Date(Number(minimumMonth[1]), Number(minimumMonth[2]) - 1, 1);
+    const currentDate = new Date(year, month - 1, 1);
+    if (currentDate < minimumDate) {
+      return [`${year}-${String(month).padStart(2, "0")}`];
+    }
+    if (startDate < minimumDate) {
+      startDate = minimumDate;
+    }
   }
 
-  const previousYearMonthCount = Math.max(0, 4 - month);
-  for (let offset = 0; offset < previousYearMonthCount; offset += 1) {
-    keys.push(`${year - 1}-${String(12 - offset).padStart(2, "0")}`);
+  for (
+    let cursor = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+    cursor <= new Date(year, month - 1, 1);
+    cursor = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1)
+  ) {
+    keys.push(`${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`);
   }
 
   return keys;
@@ -1168,27 +1194,10 @@ function addMonths(yearMonth, delta) {
 }
 
 function getDailyInspectionLookupMonths() {
-  const currentMonth = getCurrentYearMonth();
-  if (compareYearMonth(currentMonth, DAILY_INSPECTION_MIN_SELECTABLE_MONTH) < 0) {
-    return [currentMonth];
-  }
-
-  const lookupMonths = [];
-  let cursor = getDailyInspectionSelectableMonthStart(currentMonth);
-
-  while (compareYearMonth(cursor, currentMonth) <= 0) {
-    lookupMonths.push(cursor);
-    cursor = addMonths(cursor, 1);
-  }
-
-  return lookupMonths;
-}
-
-function getDailyInspectionSelectableMonthStart(currentMonth) {
-  const rollingStart = addMonths(currentMonth, -(DAILY_INSPECTION_MAX_SELECTABLE_MONTH_COUNT - 1));
-  return compareYearMonth(rollingStart, DAILY_INSPECTION_MIN_SELECTABLE_MONTH) < 0
-    ? DAILY_INSPECTION_MIN_SELECTABLE_MONTH
-    : rollingStart;
+  return buildSelectableMonthKeys(new Date(), {
+    minimumMonthCount: DAILY_INSPECTION_RECENT_MONTH_COUNT,
+    minimumMonthKey: DAILY_INSPECTION_MIN_SELECTABLE_MONTH,
+  });
 }
 
 function normalizeDailyInspectionChecksByDay(checksByDay) {

--- a/sinyuubuturyuu/shared-settings.js
+++ b/sinyuubuturyuu/shared-settings.js
@@ -23,6 +23,9 @@
     { value: TRUCK_TYPES.FOURTON6, label: "4トン車" }
   ]);
 
+  const DEFAULT_INSPECTION_MONTH_COUNT = 4;
+  const DEFAULT_FISCAL_YEAR_START_MONTH = 4;
+
   const KATAKANA_RE = /[\u30A1-\u30F6]/g;
   const DRIVER_WITH_READING_RE = /^(.*?)[\s　]*[（(]([^（）()]+)[）)]$/;
   const JA_COLLATOR = new Intl.Collator("ja", {
@@ -47,6 +50,59 @@
 
   function normalizeText(value) {
     return String(value ?? "").trim();
+  }
+
+  function formatYearMonth(year, month) {
+    return `${year}-${String(month).padStart(2, "0")}`;
+  }
+
+  function parseYearMonth(value) {
+    const match = /^(\d{4})-(\d{2})$/.exec(String(value || "").trim());
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    if (!Number.isInteger(year) || month < 1 || month > 12) return null;
+    return { year, month };
+  }
+
+  function buildInspectionTargetMonthKeys(date = new Date(), options = {}) {
+    const sourceDate = date instanceof Date && !Number.isNaN(date.getTime()) ? date : new Date();
+    const currentDate = new Date(sourceDate.getFullYear(), sourceDate.getMonth(), 1);
+    const currentYear = currentDate.getFullYear();
+    const currentMonth = currentDate.getMonth() + 1;
+    const minimumMonthCount = Number.isInteger(options.minimumMonthCount) && options.minimumMonthCount > 0
+      ? options.minimumMonthCount
+      : DEFAULT_INSPECTION_MONTH_COUNT;
+    const fiscalYearStartMonth = Number.isInteger(options.fiscalYearStartMonth)
+      && options.fiscalYearStartMonth >= 1
+      && options.fiscalYearStartMonth <= 12
+      ? options.fiscalYearStartMonth
+      : DEFAULT_FISCAL_YEAR_START_MONTH;
+    const rollingStartDate = new Date(currentYear, currentMonth - minimumMonthCount, 1);
+    const fiscalYearStart = currentMonth >= fiscalYearStartMonth ? currentYear : currentYear - 1;
+    const fiscalStartDate = new Date(fiscalYearStart, fiscalYearStartMonth - 1, 1);
+    let startDate = rollingStartDate < fiscalStartDate ? rollingStartDate : fiscalStartDate;
+
+    const minimumMonth = parseYearMonth(options.minimumMonthKey);
+    if (minimumMonth) {
+      const minimumDate = new Date(minimumMonth.year, minimumMonth.month - 1, 1);
+      if (currentDate < minimumDate) {
+        return [formatYearMonth(currentYear, currentMonth)];
+      }
+      if (startDate < minimumDate) {
+        startDate = minimumDate;
+      }
+    }
+
+    const monthKeys = [];
+    for (
+      let cursor = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+      cursor <= currentDate;
+      cursor = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1)
+    ) {
+      monthKeys.push(formatYearMonth(cursor.getFullYear(), cursor.getMonth() + 1));
+    }
+    return monthKeys;
   }
 
   function normalizeLoginId(value) {
@@ -586,6 +642,7 @@
     normalizeVehicleProfiles,
     normalizeUserProfiles,
     normalizeCurrentTruckType,
+    buildInspectionTargetMonthKeys,
     truckTypeLabel
   });
 })();

--- a/sinyuubuturyuu/sw.js
+++ b/sinyuubuturyuu/sw.js
@@ -1,10 +1,10 @@
-const CACHE_NAME = "sinyuubuturyuu-launcher-v27";
+const CACHE_NAME = "sinyuubuturyuu-launcher-v28";
 const APP_SHELL = [
   "./",
   "./index.html",
   "./launcher.css?v=20260727b",
-  "./launcher.js?v=20260727a",
-  "./shared-settings.js?v=20260727a",
+  "./launcher.js?v=20260801a",
+  "./shared-settings.js?v=20260801a",
   "./getujitiretenkenhyou/firebase/firebase-config.js?v=20260727a",
   "./auth/firebase-auth.js?v=20260727a",
   "./getujitiretenkenhyou/firebase/firebase-cloud-sync.js?v=20260727a",


### PR DESCRIPTION
## 変更内容
- タイヤ点検表と月次日常点検表の未入力月を、直近4か月に加えて当年度の未入力月も対象に変更
- ランチャーの完了画像判定にも同じ年度基準を適用
- 更新したスクリプトとService Workerのキャッシュバージョンを更新

## 確認内容
- 変更対象JavaScriptの構文チェック
- 年度境界を含む対象月生成テスト
- 4月未入力時の完了判定テスト
- 全月境界テスト
- git diff --check