### PR TITLE
パソコン版タイヤ点検の偏摩耗に三角を追加

### DIFF
--- a/sinyuubuturyuu-pc/getujitiretenkenhyou-pc/admin.js
+++ b/sinyuubuturyuu-pc/getujitiretenkenhyou-pc/admin.js
@@ -8,7 +8,7 @@
     maker: ["ミシュラン", "サイルン", "チャオヤン", "トーヨー", "ジンユー", "ブリヂストン", "ダンロップ", "ヨコハマ"],
     type: ["ノーマル", "スタッドレス", "再生", "リグ"],
     groove: ["○", "△", "☓"],
-    wear: ["○", "☓"],
+    wear: ["○", "△", "☓"],
     damage: ["○", "☓"],
     pressure: ["○", "☓"]
   };
@@ -847,7 +847,14 @@
       return text;
     }
 
-    if (field === "wear" || field === "damage" || field === "pressure") {
+    if (field === "wear") {
+      if (isCircle) return "○";
+      if (isTriangle) return "△";
+      if (isCross) return "☓";
+      return text;
+    }
+
+    if (field === "damage" || field === "pressure") {
       if (isCircle) return "○";
       if (isCross) return "☓";
       return text;


### PR DESCRIPTION
## 変更内容

- パソコン版タイヤ点検の編集モードで、偏摩耗に「△」を追加
- 「▲」「三角」「さんかく」を偏摩耗の「△」へ正規化
- キズと空気圧の選択仕様は変更なし

## 原因

パソコン版編集画面の偏摩耗候補が「○」「☓」だけで定義され、スマホ版にある「△」が漏れていました。

## 影響

パソコン版の編集画面から偏摩耗を「△」へ変更できるようになります。

## 確認

- `node --check sinyuubuturyuu-pc/getujitiretenkenhyou-pc/admin.js`
- `git diff --check`
