### PR TITLE
パソコン版タイヤ点検のキャッシュを更新

### DIFF
--- a/sinyuubuturyuu-pc/getujitiretenkenhyou-pc/index.html
+++ b/sinyuubuturyuu-pc/getujitiretenkenhyou-pc/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="../version-sync.js"></script>
+  <script src="../version-sync.js?v=20260806a"></script>
   <script>
     (function () {
       const versionSync = window.SinyuubuturyuuPcVersion || null;
-      const version = versionSync ? versionSync.ensureLatestVersion("20260409b") : "20260409b";
+      const version = versionSync ? versionSync.ensureLatestVersion("20260806a") : "20260806a";
       if (!version) return;
       window.__SINYUUBUTURYUU_PC_VERSION__ = version;
     })();

--- a/sinyuubuturyuu-pc/version-sync.js
+++ b/sinyuubuturyuu-pc/version-sync.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
 
-  const LATEST_PC_APP_VERSION = "20260729a";
+  const LATEST_PC_APP_VERSION = "20260806a";
   const VERSION_PARAM = "v";
 
   function getVersion(fallbackVersion) {


### PR DESCRIPTION
## 変更内容

- パソコン版の共通キャッシュバージョンを `20260806a` に更新
- タイヤ点検画面から `version-sync.js` をバージョン付きURLで読み込み
- タイヤ点検画面のフォールバックバージョンを共通バージョンへ統一

## 原因

偏摩耗に「△」を追加した `admin.js` の変更後も読み込みURLが以前と同じだったため、利用者のブラウザが古いJavaScriptを再利用できる状態でした。

## 影響

タイヤ点検画面が `admin.js?v=20260806a` を取得し、偏摩耗の「△」を確実に読み込めるようになります。

## 確認

- `node --check sinyuubuturyuu-pc/version-sync.js`
- `git diff --check`
